### PR TITLE
Feature/admin preview transcripts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,7 @@ end
 
 group :test do
   gem 'capybara', '>= 2.15', '< 4.0'
+  gem 'launchy', '~> 2.4.0'
   gem 'selenium-webdriver'
   gem 'chromedriver-helper'
   gem 'shoulda-matchers', '~> 3.1', require: false
@@ -140,4 +141,3 @@ gem 'formdata'
 gem 'sidekiq'
 gem 'whenever', require: false
 gem "chartkick"
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -695,6 +695,7 @@ DEPENDENCIES
   invisible_captcha
   jbuilder (~> 2.5)
   jquery-rails
+  launchy (~> 2.4.0)
   letter_opener
   listen (>= 3.0.5, < 3.2)
   mini_magick (~> 4.8)

--- a/app/controllers/transcripts_controller.rb
+++ b/app/controllers/transcripts_controller.rb
@@ -31,6 +31,10 @@ class TranscriptsController < ApplicationController
   # GET /transcripts/the-uid
   # GET /transcripts/the-uid.json
   def show
+    if logged_in_user.admin? || logged_in_user.content_editor?
+      @transcript = Transcript.find_by(uid: params[:id])
+    end
+
     respond_to do |format|
       format.html {
         # If this is the Facebook scraper, redirect to a page that includes the Open Graph meta tags.

--- a/app/models/transcript.rb
+++ b/app/models/transcript.rb
@@ -46,7 +46,7 @@ class Transcript < ApplicationRecord
   end
 
   def transcription_conventions
-    collection.institution.transcription_conventions
+    collection&.institution&.transcription_conventions
   end
 
   # speakers getters and setters used to manage the transcript_speakers

--- a/app/views/admin/cms/collections/_item_list.html.erb
+++ b/app/views/admin/cms/collections/_item_list.html.erb
@@ -1,8 +1,9 @@
 <!-- find_each was removed to support odering in collection.transcripts -->
 <% order_transcripts_asc(@collection.transcripts).each do |item| %>
   <div class="row">
-    <div class="col-1"><%= publish_icon(item.published?) %></div>
-    <div class="col-5"><%= item.title %></div>
+    <div class="col-5">
+      <%= publish_icon(item.published?) %>
+      <%= item.title %></div>
     <div class="col-2">
       <%= image_tag(item.image_url(:thumb)) if item.image.url.present? %>
     </div>
@@ -19,11 +20,19 @@
       <% end if item.voicebase? %>
     </div>
     <div class="col-1">
+      <%= link_to transcript_path(item, preview: true),
+        method: "get",
+        data: { disable_with: "Loading..." }, target: '_blank' do
+      %>
+        <%= fa_icon "eye" %>
+      <% end %>
+    </div>
+    <div class="col-1">
       <%= button_to edit_admin_cms_transcript_path(item),
         method: "get",
         data: { disable_with: "Loading..." } do
       %>
-      <%= fa_icon "edit" %>
+        <%= fa_icon "edit" %>
       <% end %>
     </div>
     <div class="col-1">

--- a/app/views/admin/cms/collections/_item_list.html.erb
+++ b/app/views/admin/cms/collections/_item_list.html.erb
@@ -22,7 +22,7 @@
     <div class="col-1">
       <%= link_to transcript_path(item, preview: true),
         method: "get",
-        data: { disable_with: "Loading..." }, target: '_blank' do
+        target: '_blank' do
       %>
         <%= fa_icon "eye" %>
       <% end %>

--- a/app/views/admin/cms/collections/show.html.erb
+++ b/app/views/admin/cms/collections/show.html.erb
@@ -53,11 +53,10 @@
   <h3 class="item-list-title">Items</h3>
   <br/>
   <div class="row item-list-headings">
-    <div class="col-1"></div>
     <div class="col-5">Title</div>
     <div class="col-2">Image</div>
     <div class="col-1">status</div>
-    <div class="col-3 text-center">Actions</div>
+    <div class="col-4 text-center">Actions</div>
   </div>
   <hr/>
 </header>

--- a/app/views/transcripts/show.json.jbuilder
+++ b/app/views/transcripts/show.json.jbuilder
@@ -2,7 +2,9 @@ json.extract! @transcript, :id, :uid, :title, :description, :url, :audio_url, :i
 :audio_item_url_title,
 :image_item_url_title
 
-json.transcript_status @transcript.transcript_status, :id, :name, :progress, :description
+unless @transcript.transcript_status.nil?
+  json.transcript_status @transcript.transcript_status, :id, :name, :progress, :description
+end
 
 collection = @transcript.collection
 
@@ -28,5 +30,7 @@ unless @user_role.nil?
   json.user_role @user_role, :id, :name, :hiearchy
 end
 
-json.conventions @transcription_conventions, :convention_key, :convention_text, :example
+unless @transcription_conventions.nil?
+  json.conventions @transcription_conventions, :convention_key, :convention_text, :example
+end
 json.instructions @instructions, :content

--- a/spec/features/transcripts/transcript_preview_spec.rb
+++ b/spec/features/transcripts/transcript_preview_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.feature 'Transcript Preview', type: :feature do
+RSpec.feature 'Transcript Preview' do
   let(:transcript) { create(:transcript, published_at: nil) }
   let!(:my_page) { create(:page, page_type: 'instructions') }
   let!(:public_page) { create(:public_page, page: my_page) }
 
-  describe 'can see an unpublished transcript preview page' do
+  describe 'can see an unpublished transcript preview page', js: true do
     context 'as an admin' do
       let(:admin) { create(:user, :admin) }
 
@@ -14,7 +14,7 @@ RSpec.feature 'Transcript Preview', type: :feature do
         visit transcript_path(transcript, preview: true)
       end
 
-      it 'shows the preview page', js: true do
+      it 'shows the preview page' do
         expect(page).to have_text(transcript.title)
         expect(page).to have_current_path(transcript_path(transcript, preview: true))
       end
@@ -28,7 +28,7 @@ RSpec.feature 'Transcript Preview', type: :feature do
         visit transcript_path(transcript, preview: true)
       end
 
-      it 'shows the preview page', js: true do
+      it 'shows the preview page' do
         expect(page).to have_text(transcript.title)
         expect(page).to have_current_path(transcript_path(transcript, preview: true))
       end
@@ -42,7 +42,7 @@ RSpec.feature 'Transcript Preview', type: :feature do
         visit transcript_path(transcript, preview: true)
       end
 
-      it "doesn't show the preview of the unpublished transcript", js: true do
+      it "doesn't show the preview of the unpublished transcript" do
         expect(page).to_not have_text(transcript.title)
         expect(page).to_not have_text('Error 500 Internal server error')
         expect(page).to have_current_path(transcript_path(transcript, preview: true))

--- a/spec/features/transcripts/transcript_preview_spec.rb
+++ b/spec/features/transcripts/transcript_preview_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.feature 'Transcript Preview', type: :feature do
+  let(:transcript) { create(:transcript, published_at: nil) }
+  let!(:my_page) { create(:page, page_type: 'instructions') }
+  let!(:public_page) { create(:public_page, page: my_page) }
+
+  describe 'can see an unpublished transcript preview page' do
+    context 'as an admin' do
+      let(:admin) { create(:user, :admin) }
+
+      before do
+        sign_in admin
+        visit transcript_path(transcript, preview: true)
+      end
+
+      it 'shows the preview page', js: true do
+        expect(page).to have_text(transcript.title)
+        expect(page).to have_current_path(transcript_path(transcript, preview: true))
+      end
+    end
+
+    context 'as a content editor' do
+      let(:content_editor) { create(:user, :content_editor) }
+
+      before do
+        sign_in content_editor
+        visit transcript_path(transcript, preview: true)
+      end
+
+      it 'shows the preview page', js: true do
+        expect(page).to have_text(transcript.title)
+        expect(page).to have_current_path(transcript_path(transcript, preview: true))
+      end
+    end
+
+    context 'as a normal user' do
+      let(:user) { create(:user) }
+
+      before do
+        sign_in user
+        visit transcript_path(transcript, preview: true)
+      end
+
+      it "doesn't show the preview of the unpublished transcript", js: true do
+        expect(page).to_not have_text(transcript.title)
+        expect(page).to_not have_text('Error 500 Internal server error')
+        expect(page).to have_current_path(transcript_path(transcript, preview: true))
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,6 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 
 include ActionDispatch::TestProcess
-include Rack::Test::Methods
 
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,30 @@
+require 'capybara/rails'
+require 'capybara/rspec'
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+    clear_session_storage: true,
+    clear_local_storage: true,
+    options: Selenium::WebDriver::Chrome::Options.new
+end
+
+Capybara.register_driver :chrome_headless do |app|
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+    clear_session_storage: true,
+    clear_local_storage: true,
+    options: Selenium::WebDriver::Chrome::Options.new(
+      args: %w[headless disable-gpu no-sandbox],
+    )
+end
+
+Capybara.javascript_driver = :chrome_headless
+
+Capybara.server = :webrick
+
+RSpec.configure do |config|
+  config.before(:each, js: true) do
+    visit '/'
+  end
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,3 +1,4 @@
 RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :feature
 end


### PR DESCRIPTION
Added a link to Preview the Transcripts on the Admin CMS side of the app:
<img width="1610" alt="Screenshot 2019-06-03 at 03 11 37" src="https://user-images.githubusercontent.com/38136087/58820402-761ef700-862a-11e9-833c-c1c027925202.png">

Clicking on the Preview link will open a new tab with the Transcript show page which will allow admins and content editors to see a preview, even if the Transcript is still a draft:
<img width="1610" alt="Screenshot 2019-06-03 at 03 04 57" src="https://user-images.githubusercontent.com/38136087/58820865-b03cc880-862b-11e9-912e-27c55907545a.png">