### PR TITLE
Feature/changes to cropping

### DIFF
--- a/app/assets/javascripts/transcripts.js
+++ b/app/assets/javascripts/transcripts.js
@@ -57,20 +57,31 @@ var ImageCrop,
 ImageCrop = (function() {
   function ImageCrop() {
     this.update = bind(this.update, this);
-    $('#cropbox').Jcrop({
-      allowResize: false,
-      allowSelect: false,
-      setSelect: [0, 0, 2000, 900],
+    var image = $('#cropbox');
+
+    var width = parseInt(image.width());
+    var height = parseInt(image.height());
+    image.Jcrop({
+      aspectRatio: 20 / 9,
+      setSelect: [0, 0, width, height],
       onSelect: this.update,
       onChange: this.update
     });
   }
 
   ImageCrop.prototype.update = function(coords) {
-    $('#transcript_crop_x').val(coords.x);
-    $('#transcript_crop_y').val(coords.y);
-    $('#transcript_crop_w').val(coords.w);
-    $('#transcript_crop_h').val(coords.h);
+    // Ensuring the right coordinates are being set by calculating the differences
+    // between the original image size and the currently scaled (responisve) one.
+    var image = $('#cropbox');
+    var oldWidth = parseInt(image[0].naturalWidth);
+    var oldHeight = parseInt(image[0].naturalHeight);
+    var newWidth = parseInt(image.width());
+    var newHeight = parseInt(image.height());
+
+    $('#transcript_crop_x').val(coords.x * (oldWidth / newWidth));
+    $('#transcript_crop_y').val(coords.y * (oldHeight / newHeight));
+    $('#transcript_crop_w').val(coords.w * (oldWidth / newWidth));
+    $('#transcript_crop_h').val(coords.h * (oldHeight / newHeight));
   };
   return ImageCrop;
 })();

--- a/app/assets/javascripts/transcripts.js
+++ b/app/assets/javascripts/transcripts.js
@@ -87,7 +87,7 @@ ImageCrop = (function() {
 
   ImageCrop.prototype.update = function(coords) {
     // Ensuring the right coordinates are being set by calculating the differences
-    // between the original image size and the currently scaled (responisve) one.
+    // between the original image size and the currently scaled (responsive) one.
     var image = $('#cropbox');
     var oldWidth = parseInt(image[0].naturalWidth);
     var oldHeight = parseInt(image[0].naturalHeight);

--- a/app/assets/javascripts/transcripts.js
+++ b/app/assets/javascripts/transcripts.js
@@ -15,17 +15,33 @@ $(document).ready(function(){
   $('.upload-image').on('change', function() {
     destroyImageCropObject();
     var input = this;
+    var _URL = window.URL || window.webkitURL;
+    var img;
 
     if (input.files && input.files[0]) {
-      var reader = new FileReader();
+      img = new Image();
+      img.src = _URL.createObjectURL(input.files[0]);
 
-      reader.onload = function(e) {
-        $('#cropbox').attr('src', e.target.result);
-      };
+      // Adds a preview of the uploaded image if its dimensions are equal or above 1000x450.
+      window.setTimeout(function() {
+        var width = img.width;
+        var height = img.height;
 
-      reader.readAsDataURL(input.files[0]);
+        if (width >= 1000 && height >= 450) {
+          var reader = new FileReader();
+
+          reader.onload = function(e) {
+            $('#cropbox').attr('src', e.target.result);
+          };
+
+          reader.readAsDataURL(input.files[0]);
+          createImageCropObject();
+        } else {
+          $('.upload-image').val('');
+          alert('Please make sure your image dimensions are at least 1000x450.');
+        }
+      }, 100 );
     }
-    createImageCropObject()
   });
 
   $('.recrop-original').on('click', function() {

--- a/app/assets/stylesheets/components/transcript_item.scss
+++ b/app/assets/stylesheets/components/transcript_item.scss
@@ -178,6 +178,7 @@
     overflow: scroll;
 
     #cropbox {
+      max-width: 100%;
       height: auto;
     }
   }

--- a/app/views/admin/cms/transcripts/_transcript_file.html.erb
+++ b/app/views/admin/cms/transcripts/_transcript_file.html.erb
@@ -18,7 +18,7 @@
       Upload a New Image
     </h5>
     <div class="alert-warning mb-2" role="alert">
-      Your transcript image will be resized to 2000x900 pixels, so please make sure your image has the necessary dimensions.
+      Please make sure your image dimensions are at least 1000x450.
     </div>
 
     <div class="form-group actions">

--- a/app/views/admin/cms/transcripts/_transcript_file.html.erb
+++ b/app/views/admin/cms/transcripts/_transcript_file.html.erb
@@ -5,7 +5,7 @@
         Current Image
       </h5>
       <div class="form-group dotted-border-container">
-        <%= image_tag transcript.image_url(:cropped_thumb), id:"cropbox", src:"#" %>
+        <%= image_tag transcript.image_url(:cropped_thumb), class: 'img-fluid', id:"cropbox", src:"#" %>
       </div>
     <% else %>
       <img id="cropbox">


### PR DESCRIPTION
On the Transcript edit page, instead of displaying the full-size image and locking the cropping selection to 2000x900, we are now displaying the image responsively and the selection will keep a 20 /  9 aspect ratio:
<img width="1231" alt="Screenshot 2019-06-06 at 18 03 56" src="https://user-images.githubusercontent.com/38136087/59073701-075acb80-88c0-11e9-8805-3ee8c4f2f151.png">
Also, when uploading an image we check if its dimensions are superior to 1000x450.