### PR TITLE
[AM-131] Fix statistics calculation errors

### DIFF
--- a/app/helpers/admin/summary_helper.rb
+++ b/app/helpers/admin/summary_helper.rb
@@ -6,12 +6,12 @@ module Admin::SummaryHelper
     {
       h: total_seconds / (60 * 60),
       m: (total_seconds / 60) % 60,
-      s: total_seconds % 60
+      s: total_seconds % 60,
     }.map do |suffix, time|
       # Right justify and pad with 0 until length is 2.
       # So if the duration of any of the time components is 0,
       # then it will display as 00.
       "#{time.round.to_s.rjust(2, '0')}#{suffix}"
-    end.join(' ')
+    end.join(" ")
   end
 end

--- a/app/helpers/admin/summary_helper.rb
+++ b/app/helpers/admin/summary_helper.rb
@@ -1,7 +1,17 @@
 module Admin::SummaryHelper
   include Admin::StatsHelper
 
-  def prettify_duration(duration)
-    Time.at(duration).utc.strftime("%Hh %Mm %Ss")
+  # @see https://gist.github.com/shunchu/3175001#gistcomment-2197179
+  def duration_to_hms(total_seconds)
+    {
+      h: total_seconds / (60 * 60),
+      m: (total_seconds / 60) % 60,
+      s: total_seconds % 60
+    }.map do |suffix, time|
+      # Right justify and pad with 0 until length is 2.
+      # So if the duration of any of the time components is 0,
+      # then it will display as 00.
+      "#{time.round.to_s.rjust(2, '0')}#{suffix}"
+    end.join(' ')
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -46,6 +46,12 @@ class Collection < ApplicationRecord
     uid
   end
 
+  def duration
+    Rails.cache.fetch("Collection:duration:#{self.id}", expires_in: 1.hour) do
+      transcripts.map(&:duration).inject(0) { |memo, duration| memo + duration }
+    end
+  end
+
   def disk_usage
     Rails.cache.fetch("Collection:disk_usage:#{self.id}", expires_in: 1.hour) do
       transcripts.map(&:disk_usage)

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -65,6 +65,12 @@ class Institution < ApplicationRecord
     end
   end
 
+  def duration
+    Rails.cache.fetch("Institution:duration:#{self.id}", expires_in: 1.hour) do
+      collections.map(&:duration).inject(0) { |memo, duration| memo + duration }
+    end
+  end
+
   def disk_usage
     Rails.cache.fetch("Institution:disk_usage:#{self.id}", expires_in: 1.hour) do
       collections.map(&:disk_usage)

--- a/app/views/admin/cms/collections/_form.html.erb
+++ b/app/views/admin/cms/collections/_form.html.erb
@@ -69,4 +69,8 @@
     <%= f.submit "Save", class: "btn btn-primary" %>
     <%= link_to "Cancel", admin_cms_path %>
   </div>
+
+  <div class="form-group">
+    <%= render partial: "admin/cms/shared/stats", locals: { stats_type: 'collection', transcript_count: @collection.transcripts.length, duration: @collection.duration, usage: @collection.disk_usage } %>
+  </div>
 <% end %>

--- a/app/views/admin/cms/shared/_stats.html.erb
+++ b/app/views/admin/cms/shared/_stats.html.erb
@@ -1,0 +1,28 @@
+<div class="well">
+  <h2>Statistics for this <%= stats_type %></h2>
+  <dl>
+    <% if defined?(collection_count) && stats_type == 'institution' %>
+      <dt>Collections</dt>
+      <dd data-raw="<%= collection_count %>"><%= number_to_human collection_count %></dd>
+    <% end %>
+    <% if defined?(transcript_count) && (stats_type == 'collection' || stats_type == 'institution') %>
+      <dt>Transcripts</dt>
+      <dd data-raw="<%= transcript_count %>"><%= number_to_human transcript_count %></dd>
+    <% end %>
+    <dt>Audio duration</dt>
+    <dd data-raw="<%= duration %>">
+      <%= duration_to_hms duration %>
+    </dd>
+    <dt>File sizes per type</dt>
+    <dd data-raw="<%= usage.to_json %>">
+      <ul>
+        <% usage.each do |ft, u| %>
+          <li>
+            <strong><%= ft.capitalize %>:</strong>
+            <span><%= number_to_human_size u %></span>
+          </li>
+        <% end %>
+      </ul>
+    </dd>
+  </dl>
+</div>

--- a/app/views/admin/cms/transcripts/_form.html.erb
+++ b/app/views/admin/cms/transcripts/_form.html.erb
@@ -118,10 +118,13 @@
         Uploading your audio file may take a few minutes. After clicking the 'Save transcript' button, do not close your browser or navigate away from this page. When your file upload is complete you will be redirected to the transcript index page.
       </div>
 
-
       <div class="form-group text-center mb-2">
         <%= f.submit('Save Transcript', class: 'btn btn-primary') %>
         <%= link_to "Cancel", admin_cms_collection_path(@transcript.collection.uid) %>
+      </div>
+
+      <div class="form-group">
+        <%= render partial: "admin/cms/shared/stats", locals: { stats_type: 'transcript', duration: @transcript.duration, usage: @transcript.disk_usage } %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/institutions/_form.html.erb
+++ b/app/views/admin/institutions/_form.html.erb
@@ -48,4 +48,8 @@
 
 
   <%= form.submit 'Save', class: 'btn btn-primary' %>
+
+  <div class="form-group">
+    <%= render partial: "admin/cms/shared/stats", locals: { stats_type: 'institution', collection_count: institution.collections.count, transcript_count: institution.collections.map { |c| c.transcripts.length }.inject(0, :+), duration: institution.duration, usage: institution.disk_usage } %>
+  </div>
 <% end %>

--- a/app/views/admin/summary/_summary_stats.html.erb
+++ b/app/views/admin/summary/_summary_stats.html.erb
@@ -1,5 +1,5 @@
 <h3>Total number of items: <%= total[:total] %></h3>
-<p>Total duration of items: <%= prettify_duration(duration) %></p>
+<p>Total duration of items: <%= duration_to_hms duration %></p>
 <table class="table table table-striped">
   <tbody>
     <% stats.each do |key, val| %>

--- a/spec/helpers/admin/summary_helper_spec.rb
+++ b/spec/helpers/admin/summary_helper_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Admin::SummaryHelper, type: :helper do
-  describe '.prettify_duration' do
+  describe '.duration_to_hms' do
     it 'returns a humanized duration string from an integer' do
-      expect(helper.prettify_duration(2000)).to eq('00h 33m 20s')
+      expect(helper.duration_to_hms(2000)).to eq('00h 33m 20s')
+      expect(helper.duration_to_hms(86401)).to eq('24h 00m 01s')
     end
   end
 end


### PR DESCRIPTION
* Change `prettify_duration` to `duration_to_hms` to make purpose more obvious
  * Fix day rollover calculation by computing hours/minutes/seconds instead of trusting the date libraries too much
* Add more helpers to calculate duration of collections/institutions
* Set up stats panel that transcripts/collections/institutions can use to display info while editing