### PR TITLE
Example init.d script

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,11 @@ rake cache:clear
 
 ### Activating user accounts
 
-This app currently supports logging in through Google or Facebook accounts (via [OAuth2](https://en.wikipedia.org/wiki/OAuth)).  You can activate this by the following:
+This app currently supports logging in through Google or Facebook accounts
+(via [OAuth2](https://en.wikipedia.org/wiki/OAuth)).
+You can activate this by the following procedures.
+
+[Find out more about authentication in Amplify here.](docs/authentication.md)
 
 #### Instructions for Google Account activation
 
@@ -640,52 +644,9 @@ bundle exec rake transcripts:load['nsw-state-library-amplify','transcripts_seeds
 bundle exec rake voice_base:import_transcripts['nsw-state-library-amplify']
 ```
 
-### Background tasks
+### Services and background tasks
 
-This application uses Sidekiq to manage background tasks. We recommend you use
-systemd to run Sidekiq in your staging and production environments.
-The commands provided by capistrano-sidekiq will generate a systemd service
-file for you, but if you're using RVM to manage your rubies, change the
-`ExecStart` command to wrap it in `/bin/bash -lc`.
-
-We have a sample systemd unit file that works with RVM here:
-[sidekiq-env.service](docs/examples/sidekiq-env.service)
-
-You'll want to add your file to `~/.config/systemd/user`, and then
-symlink it to `~/.config/systemd/user/default.user.wants/sidekiq-yourenv.service`.
-
-For more info, take a look at [sidekiq's sample systemd unit file](https://github.com/mperham/sidekiq/blob/master/examples/systemd/sidekiq.service).
-
-#### Troubleshooting: Failed to connect to bus
-
-When running `systemctl --user` as your deploy user,
-you might see a message along the lines of:
-
-```text
-Failed to connect to bus: No such file or directory
-```
-
-This is usually a sign that systemd hasn't been set up for your user right.
-
-As the root user, ensure that your deploy user is using `/bin/bash` as
-their login shell. Use the `chsh` command to change it if necessary.
-
-As the root user, run `loginctl enable-linger <name-of-deploy-user>` to enable
-services that persist when a login session is not running.
-
-Finally, add the following (verbatim) to your user's `.bashrc` file:
-
-```bash
-export XDG_RUNTIME_DIR="/run/user/$UID"
-export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
-```
-
-Log out and log back in as your deploy user so your changes can take effect.
-
-For more info:
-
-* https://www.freedesktop.org/software/systemd/man/loginctl.html
-* https://gist.github.com/Cretezy/dc64ed4519c63c3eb636fba354f93a1f
+[Find out more about services and background tasks in Amplify here.](docs/services.md)
 
 ## Managing your project
 

--- a/config/amplify-init-example.sh
+++ b/config/amplify-init-example.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          amplify_puma
+# Required-Start:    $local_fs $network $named $time $syslog
+# Required-Stop:     $local_fs $network $named $time $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Description:       Runs Amplify server via Puma.
+### END INIT INFO
+
+RUNAS=deploy
+RUNAS_UID=$(id -u $RUNAS)
+
+APP_DIR="/home/$RUNAS/nsw-state-library-amplify/current"
+RVM_BIN="/home/$RUNAS/.rvm/bin/rvm"
+RVM_RUBY="ruby-2.5.3"
+PUMA_SCRIPT="/home/$RUNAS/nsw-state-library-amplify/shared/puma.rb"
+PUMA_STATE="/home/$RUNAS/nsw-state-library-amplify/shared/tmp/pids/puma.state"
+SIDEKIQ_SERVICE="sidekiq-staging.service"
+
+start() {
+  echo 'Trying to start service…' >&2
+  su -c "cd $APP_DIR && $RVM_BIN $RVM_RUBY do bundle exec puma -C $PUMA_SCRIPT --daemon" $RUNAS
+  su -c "XDG_RUNTIME_DIR=/run/user/$RUNAS_UID systemctl --user start $SIDEKIQ_SERVICE" $RUNAS
+  echo 'Service started' >&2
+}
+
+stop() {
+  echo 'Stopping service…' >&2
+  su -c "cd $APP_DIR && $RVM_BIN $RVM_RUBY do bundle exec pumactl -S $PUMA_STATE -F $PUMA_SCRIPT stop" $RUNAS
+  su -c "XDG_RUNTIME_DIR=/run/user/$RUNAS_UID systemctl --user stop $SIDEKIQ_SERVICE" $RUNAS
+  echo 'Service stopped' >&2
+}
+
+restart() {
+  echo 'Trying to restart service…' >&2
+  su -c "cd $APP_DIR && $RVM_BIN $RVM_RUBY do bundle exec pumactl -S $PUMA_STATE -F $PUMA_SCRIPT restart" $RUNAS
+  su -c "XDG_RUNTIME_DIR=/run/user/$RUNAS_UID systemctl --user stop $SIDEKIQ_SERVICE" $RUNAS
+  su -c "XDG_RUNTIME_DIR=/run/user/$RUNAS_UID systemctl --user start $SIDEKIQ_SERVICE" $RUNAS
+  echo 'Service started' >&2
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart)
+    restart
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart}"
+esac

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -9,12 +9,9 @@ authentication to work independently of the user interface.
 
 * Google OAuth2
 * Facebook
-* SAML
+* Email login
+* SAML (WIP)
   * Works against Azure AD
-
-Considering implementing:
-
-* Gigya
 
 ## Connecting auth providers to project
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -108,6 +108,25 @@ After updating your `project.json` file, always run
      FACEBOOK_APP_SECRET: nopqrstuvwxyz123456abcdefghijklm
   ```
 
+### Email login
+
+Email login is managed via Devise, and transactional emails are sent
+using SMTP. It requires the following parameters to be set up in
+your `config/application.yml` file.
+
+* **SENDER_EMAIL**  
+  Email address to send from.
+* **SMTP_URI**  
+  SMTP server hostname.
+* **SMTP_PORT**  
+  SMTP server port.
+* **SES_SMTP_USERNAME**  
+  SMTP server username.
+* **SES_SMTP_PASSWORD**  
+  SMTP server password.
+* **DEFAULT_MAILER_HOST**  
+  The default host for your webserver.
+
 ### SAML
 
 1. Set up your SAML app depending on how your identity provider wants you

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,0 +1,66 @@
+# Services and background tasks
+
+## Puma
+
+This application uses Puma to run the webserver. It doesn't play particularly
+nicely with systemd, but we have a few options about how we want to
+initialise the application at server boot time.
+
+We have a sample init.d script here:
+[amplify-init-example.sh](../config/amplify-init-example.sh)
+
+To set this up, copy it to `/etc/init.d/amplify`, customise it as necessary,
+make it executable `chmod a+x /etc/init.d/amplify` and run
+`update-rc.d /etc/init.d/amplify defaults` to ensures it runs at boot time.
+
+There's also a sample puma systemd unit, but it probably needs refinement:
+[puma.service](../config/puma.service)
+
+## Sidekiq
+
+This application uses Sidekiq to manage background tasks. We recommend you use
+systemd to run Sidekiq in your staging and production environments.
+The commands provided by capistrano-sidekiq will generate a systemd service
+file for you, but if you're using RVM to manage your rubies, change the
+`ExecStart` command to wrap it in `/bin/bash -lc`.
+
+We have a sample systemd unit file that works with RVM here:
+[sidekiq-env.service](./examples/sidekiq-env.service)
+
+You'll want to add your file to `~/.config/systemd/user`, and then
+symlink it to `~/.config/systemd/user/default.user.wants/sidekiq-yourenv.service`.
+
+For more info, take a look at [sidekiq's sample systemd unit file](https://github.com/mperham/sidekiq/blob/master/examples/systemd/sidekiq.service).
+
+## Troubleshooting
+
+### Failed to connect to bus
+
+When running `systemctl --user` as your deploy user,
+you might see a message along the lines of:
+
+```text
+Failed to connect to bus: No such file or directory
+```
+
+This is usually a sign that systemd hasn't been set up for your user right.
+
+As the root user, ensure that your deploy user is using `/bin/bash` as
+their login shell. Use the `chsh` command to change it if necessary.
+
+As the root user, run `loginctl enable-linger <name-of-deploy-user>` to enable
+services that persist when a login session is not running.
+
+Finally, add the following (verbatim) to your user's `.bashrc` file:
+
+```bash
+export XDG_RUNTIME_DIR="/run/user/$UID"
+export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
+```
+
+Log out and log back in as your deploy user so your changes can take effect.
+
+For more info:
+
+* https://www.freedesktop.org/software/systemd/man/loginctl.html
+* https://gist.github.com/Cretezy/dc64ed4519c63c3eb636fba354f93a1f


### PR DESCRIPTION
Example initialisation script that should help Amplify start on boot. Commands are derived from the ones that Capistrano uses to start Amplify and its services.

Tested the script on STAGING, and it starts the Amplify webserver as intended.

Additional documentation added for startup jobs, and tidied up the documentation around auth methods a little.