### PR TITLE
[AM-161] Site alerts

### DIFF
--- a/app/assets/images/icons/icon-cross-black.svg
+++ b/app/assets/images/icons/icon-cross-black.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10.82 10.82">
+  <defs><style>.cls-1{fill:#111;}</style></defs>
+  <title>icn-cross</title>
+  <g id="Layer_2" data-name="Layer 2">
+    <g id="Layer_1-2" data-name="Layer 1">
+      <path class="cls-1" d="M9.55,10.82,5.41,6.68,1.27,10.82,0,9.55,4.14,5.41,0,1.27,1.27,0,5.41,4.14,9.55,0l1.27,1.27L6.68,5.41l4.14,4.14Z"/>
+    </g>
+  </g>
+</svg>

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,6 +26,7 @@
 //= require jquery.Jcrop.min
 //= require select2
 //= require dashboard
+//= require site_alerts
 
 // Convert legacy thumbnails.
 (function () {

--- a/app/assets/javascripts/site_alerts.js
+++ b/app/assets/javascripts/site_alerts.js
@@ -1,0 +1,46 @@
+/**
+ * @file
+ * Manage user-facing list of site alerts.
+ */
+
+$(document).ready(function () {
+  // Function: Get list of closed site alerts.
+  var getClosedIds = function () {
+    return (window.localStorage.getItem('site_alerts') || '')
+      .split(',')
+      .filter(function (id) {
+        return id && id.length > 0;
+      });
+  };
+
+  // Function: Update list of closed site alerts.
+  var setClosedIds = function (closedIds) {
+    window.localStorage.setItem('site_alerts', closedIds.join(','));
+  };
+
+  // Get list of closed site alerts.
+  var closedIds = getClosedIds();
+
+  // Hide closed site alerts.
+  var validClosedIds = [];
+  $(closedIds).each(function (i, id) {
+    var alert = $('.site-alert#' + id);
+    if (alert.length > 0) {
+      alert.hide();
+      validClosedIds.push(id);
+    }
+  });
+
+  // Clean up nonexistent site alerts.
+  setClosedIds(validClosedIds);
+
+  // Handle close button for site alerts.
+  $('.site-alert__close').click(function (e) {
+    var alert = $(e.target).closest('.site-alert');
+    var id = alert.attr('id');
+    closedIds.push(id);
+    setClosedIds(closedIds);
+    alert.hide();
+  });
+});
+    

--- a/app/assets/stylesheets/base/settings_images.scss
+++ b/app/assets/stylesheets/base/settings_images.scss
@@ -3,6 +3,7 @@ $edit-background: image-url('example_hero_background');
 $home-background: image-url('home_hero_background');
 
 $cross-icon:      image-url('icons/icon-cross');
+$cross-icon-black:      image-url('icons/icon-cross-black');
 $drop-down-black: image-url('icons/icon-dropdown-black');
 $drop-down-yellow: image-url('icons/icon-dropdown-yellow');
 $drop-down-white: image-url('icons/icon-dropdown-white');

--- a/app/assets/stylesheets/components/messages.scss
+++ b/app/assets/stylesheets/components/messages.scss
@@ -109,6 +109,6 @@
   &__close {
     flex: 0 0 auto;
     border: 0 none;
-    background-image: $search-icon;
+    background-color: transparent;
   }
 }

--- a/app/assets/stylesheets/components/messages.scss
+++ b/app/assets/stylesheets/components/messages.scss
@@ -108,5 +108,7 @@
 
   &__close {
     flex: 0 0 auto;
+    border: 0 none;
+    background-image: $search-icon;
   }
 }

--- a/app/assets/stylesheets/components/messages.scss
+++ b/app/assets/stylesheets/components/messages.scss
@@ -65,3 +65,48 @@
     opacity: 0;
   }
 }
+
+.site-alert {
+  display: flex;
+  flex-direction: row;
+  padding: 1rem;
+
+  a {
+    font-weight: 700;
+  }
+
+  &--status {
+    background: #eee;
+    color: #333;
+
+    a {
+      color: #111;
+    }
+  }
+
+  &--warning {
+    background: #ff9;
+    color: #660;
+
+    a {
+      color: #330;
+    }
+  }
+
+  &--error {
+    background: #f99;
+    color: #900;
+
+    a {
+      color: #600;
+    }
+  }
+
+  &__message {
+    flex: 1 1 auto;
+  }
+
+  &__close {
+    flex: 0 0 auto;
+  }
+}

--- a/app/assets/stylesheets/objects/buttons.scss
+++ b/app/assets/stylesheets/objects/buttons.scss
@@ -75,6 +75,11 @@
       background-size: 20px 20px;
       cursor: pointer;
     }
+    &.cross-black {
+      background-image: $cross-icon-black;
+      background-size: 20px 20px;
+      cursor: pointer;
+    }
     &.search {
       @include button-background($button-yellow);
       background-image: $search-icon;

--- a/app/controllers/admin/site_alerts_controller.rb
+++ b/app/controllers/admin/site_alerts_controller.rb
@@ -1,0 +1,62 @@
+class Admin::SiteAlertsController < AdminController
+  before_action :set_site_alert, only: [:edit, :update, :destroy, :show]
+
+  def index
+    authorize SiteAlert
+    @site_alerts = policy_scope(SiteAlert).order(created_at: :desc)
+  end
+
+  def new
+    authorize SiteAlert
+    @site_alert = SiteAlert.new
+  end
+
+  def create
+    authorize SiteAlert
+
+    @site_alert = SiteAlert.new(site_alert_params)
+
+    if @site_alert.save
+      redirect_to admin_site_alerts_path
+    else
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def show
+    @site_alert = @site_alert.decorate
+  end
+
+  def update
+    if @site_alert.update(site_alert_params)
+      redirect_to admin_site_alerts_path
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @site_alert.destroy
+    redirect_to admin_site_alerts_path
+  end
+
+  private
+
+  def set_site_alert
+    @site_alert = SiteAlert.find(params[:id])
+  end
+
+  def site_alert_params
+    params.require(:site_alert).permit(
+      :level,
+      :machine_name,
+      :message,
+      :published,
+      :admin_access,
+      :publish_at,
+      :unpublish_at
+    )
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -9,6 +9,7 @@ module AdminHelper
       OpenStruct.new(path: admin_institutions_path, icon: "university", text: "Institutions", type: 2),
       OpenStruct.new(path: admin_pages_path, icon: "file", text: "Pages", type: 4),
       OpenStruct.new(path: admin_themes_path, icon: "paint-brush", text: "Themes", type: 4),
+      OpenStruct.new(path: admin_site_alerts_path, icon: "paint-brush", text: "Site Alerts", type: 4),
       OpenStruct.new(path: edit_admin_app_config_path(@app_config.id), icon: "cog", text: "Site Config", type: 4),
       OpenStruct.new(path: "/page/user_guide", icon: "question-circle", text: "User Guide", type: 2),
       OpenStruct.new(path: "/sidekiq", icon: "tasks", text: "Background queue", type: 4),

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -105,4 +105,8 @@ module ApplicationHelper
   def oauth_url(p)
     "/users#{p['path']}?state=#{@transcript.try(:uid)}"
   end
+
+  def site_alerts
+    SiteAlert.where(published: true)
+  end
 end

--- a/app/models/site_alert.rb
+++ b/app/models/site_alert.rb
@@ -1,0 +1,3 @@
+class SiteAlert < ApplicationRecord
+  has_paper_trail
+end

--- a/app/models/site_alert.rb
+++ b/app/models/site_alert.rb
@@ -1,3 +1,4 @@
 class SiteAlert < ApplicationRecord
   has_paper_trail
+  enum level: { status: 'status', warning: 'warning', error: 'error' }
 end

--- a/app/policies/site_alert_policy.rb
+++ b/app/policies/site_alert_policy.rb
@@ -1,0 +1,26 @@
+class SiteAlertPolicy < ApplicationPolicy
+    attr_reader :user, :site_alert
+  
+    def initialize(user, site_alert)
+      @user = user
+      @site_alert = site_alert
+    end
+  
+    def index?
+      @user.isAdmin?
+    end
+  
+    def update?
+      @user.isAdmin?
+    end
+  
+    class Scope < Scope
+      def resolve
+        if @user.isAdmin?
+          SiteAlert.all
+        end
+      end
+    end
+  
+  end
+  

--- a/app/views/admin/site_alerts/_admin_site_alert.json.jbuilder
+++ b/app/views/admin/site_alerts/_admin_site_alert.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! admin_site_alert, :id, :machine_name, :message, :user_id, :published, :scheduled, :publish_at, :unpublish_at, :created_at, :updated_at
+json.url admin_site_alert_url(admin_site_alert, format: :json)

--- a/app/views/admin/site_alerts/_form.html.erb
+++ b/app/views/admin/site_alerts/_form.html.erb
@@ -1,0 +1,55 @@
+<%= form_with(model: [:admin, site_alert], local: true) do |form| %>
+    <%= render 'layouts/cms_errors', object: site_alert %>
+  
+    <div class="form-group">
+      <%= form.label :level %>
+      <%= form.select :level, options_for_select(SiteAlert.levels.map{|k, v| [k, v]}), required: true, class: 'form-control' %>
+      <div class="alert-light" role="alert">
+        Specify the level of urgency indicated by this message.
+      </div>
+    </div>
+
+    <div class="form-group">
+      <%= form.label :machine_name %>
+      <%= form.text_field :machine_name, class: 'form-control', required: true, maxlength: 50 %>
+      <div class="alert-light" role="alert">
+        * <strong>Machine name</strong> is a Unique Identifier assigned to each alert created in the database. They should have the created date within them, and have the following properties:
+        <br />
+        <ul>
+          <li>- be maximum 50 characters</li>
+          <li>- not have any spaces</li>
+          <li>- only include characters that are letters, numbers, underscore (_) and hyphen (-)</li>
+        </ul>
+      </div>
+    </div>
+  
+    <div class="form-group">
+      <%= form.label :message %>
+      <%= form.text_area :message, class: 'form-control', 'data-provider': :summernote %>
+    </div>
+    <div class="form-check">
+      <%= form.check_box :published, class: 'form-check-input' %>
+      <%= form.label 'Publish version to live site', for: 'site_alert_published', class: 'form-check-label' %>
+    </div>
+    <div class="form-check">
+      <%= form.check_box :admin_access, class: 'form-check-input' %>
+      <%= form.label 'Restrict access for public users', for: 'site_alert_admin_access', class: 'form-check-label' %>
+    </div>
+    <div class="form-check">
+      <%= form.check_box :scheduled, class: 'form-check-input' %>
+      <%= form.label 'Manage published state on schedule', for: 'site_alert_scheduled', class: 'form-check-label' %>
+    </div>
+    <div class="form-group">
+        <%= form.label :publish_at %>
+        <%= form.date_select :publish_at %>
+    </div>
+    <div class="form-group">
+        <%= form.label :unpublish_at %>
+        <%= form.date_select :unpublish_at %>
+    </div>
+  
+    <br />
+  
+    <%= form.submit 'Save', class: 'btn btn-primary' %>
+  <% end %>
+  

--- a/app/views/admin/site_alerts/_form.html.erb
+++ b/app/views/admin/site_alerts/_form.html.erb
@@ -31,22 +31,25 @@
       <%= form.check_box :published, class: 'form-check-input' %>
       <%= form.label 'Publish version to live site', for: 'site_alert_published', class: 'form-check-label' %>
     </div>
-    # <div class="form-check">
-    #   <%= form.check_box :admin_access, class: 'form-check-input' %>
-    #   <%= form.label 'Restrict access for public users', for: 'site_alert_admin_access', class: 'form-check-label' %>
-    # </div>
-    # <div class="form-check">
-    #   <%= form.check_box :scheduled, class: 'form-check-input' %>
-    #   <%= form.label 'Manage published state on schedule', for: 'site_alert_scheduled', class: 'form-check-label' %>
-    # </div>
-    # <div class="form-group">
-    #     <%= form.label :publish_at %>
-    #     <%= form.date_select :publish_at %>
-    # </div>
-    # <div class="form-group">
-    #     <%= form.label :unpublish_at %>
-    #     <%= form.date_select :unpublish_at %>
-    # </div>
+
+    <% if false %>
+      <div class="form-check">
+        <%= form.check_box :admin_access, class: 'form-check-input' %>
+        <%= form.label 'Restrict access for public users', for: 'site_alert_admin_access', class: 'form-check-label' %>
+      </div>
+      <div class="form-check">
+        <%= form.check_box :scheduled, class: 'form-check-input' %>
+        <%= form.label 'Manage published state on schedule', for: 'site_alert_scheduled', class: 'form-check-label' %>
+      </div>
+      <div class="form-group">
+          <%= form.label :publish_at %>
+          <%= form.date_select :publish_at %>
+      </div>
+      <div class="form-group">
+          <%= form.label :unpublish_at %>
+          <%= form.date_select :unpublish_at %>
+      </div>
+    <% end %>
   
     <br />
   

--- a/app/views/admin/site_alerts/_form.html.erb
+++ b/app/views/admin/site_alerts/_form.html.erb
@@ -31,22 +31,22 @@
       <%= form.check_box :published, class: 'form-check-input' %>
       <%= form.label 'Publish version to live site', for: 'site_alert_published', class: 'form-check-label' %>
     </div>
-    <div class="form-check">
-      <%= form.check_box :admin_access, class: 'form-check-input' %>
-      <%= form.label 'Restrict access for public users', for: 'site_alert_admin_access', class: 'form-check-label' %>
-    </div>
-    <div class="form-check">
-      <%= form.check_box :scheduled, class: 'form-check-input' %>
-      <%= form.label 'Manage published state on schedule', for: 'site_alert_scheduled', class: 'form-check-label' %>
-    </div>
-    <div class="form-group">
-        <%= form.label :publish_at %>
-        <%= form.date_select :publish_at %>
-    </div>
-    <div class="form-group">
-        <%= form.label :unpublish_at %>
-        <%= form.date_select :unpublish_at %>
-    </div>
+    # <div class="form-check">
+    #   <%= form.check_box :admin_access, class: 'form-check-input' %>
+    #   <%= form.label 'Restrict access for public users', for: 'site_alert_admin_access', class: 'form-check-label' %>
+    # </div>
+    # <div class="form-check">
+    #   <%= form.check_box :scheduled, class: 'form-check-input' %>
+    #   <%= form.label 'Manage published state on schedule', for: 'site_alert_scheduled', class: 'form-check-label' %>
+    # </div>
+    # <div class="form-group">
+    #     <%= form.label :publish_at %>
+    #     <%= form.date_select :publish_at %>
+    # </div>
+    # <div class="form-group">
+    #     <%= form.label :unpublish_at %>
+    #     <%= form.date_select :unpublish_at %>
+    # </div>
   
     <br />
   

--- a/app/views/admin/site_alerts/edit.html.erb
+++ b/app/views/admin/site_alerts/edit.html.erb
@@ -1,0 +1,8 @@
+<%= link_to 'Back to site alerts list', admin_site_alerts_path %>
+
+<%= render partial: 'layouts/admin_side_pane' %>
+
+<h1>Editing Page</h1>
+
+<%= render 'form', site_alert: @site_alert %>
+

--- a/app/views/admin/site_alerts/index.html.erb
+++ b/app/views/admin/site_alerts/index.html.erb
@@ -7,7 +7,7 @@
       <th scope="col">Level</th>
       <th scope="col">Message</th>
       <th scope="col">Published</th>
-      <th scope="col">Scheduled</th>
+      # <th scope="col">Scheduled</th>
       <th colspan="2" scope="col"></th>
     </tr>
   </thead>
@@ -18,7 +18,7 @@
         <td><%= site_alert.level.capitalize %></td>
         <td><%= site_alert.message %></td>
         <td><%= site_alert.published %></td>
-        <td><%= site_alert.scheduled %></td>
+        # <td><%= site_alert.scheduled %></td>
 
         <td>
           <%= link_to edit_admin_site_alert_path(site_alert)  do %>

--- a/app/views/admin/site_alerts/index.html.erb
+++ b/app/views/admin/site_alerts/index.html.erb
@@ -1,0 +1,40 @@
+<%= render partial: 'layouts/admin_side_pane' %>
+
+<h1>Site Alerts</h1>
+<table class="table">
+  <thead class="thead-dark">
+    <tr>
+      <th scope="col">Level</th>
+      <th scope="col">Message</th>
+      <th scope="col">Published</th>
+      <th scope="col">Scheduled</th>
+      <th colspan="2" scope="col"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @site_alerts.each do |site_alert| %>
+      <tr>
+        <td><%= site_alert.level.capitalize %></td>
+        <td><%= site_alert.message %></td>
+        <td><%= site_alert.published %></td>
+        <td><%= site_alert.scheduled %></td>
+
+        <td>
+          <%= link_to edit_admin_site_alert_path(site_alert)  do %>
+            <%= fa_icon "edit" %>
+          <% end %>
+        </td>
+        <td>
+          <%= button_to admin_site_alert_path(site_alert), data: {confirm: 'Are you sure you want to delete this site alert? This action cannot be undone.'}, method: :delete do %>
+            <%= fa_icon "trash" %>
+          <% end %>
+        </td>
+
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+<%= link_to 'New Site Alert', new_admin_site_alert_path, class: 'btn btn-primary' %>

--- a/app/views/admin/site_alerts/index.html.erb
+++ b/app/views/admin/site_alerts/index.html.erb
@@ -7,7 +7,11 @@
       <th scope="col">Level</th>
       <th scope="col">Message</th>
       <th scope="col">Published</th>
-      # <th scope="col">Scheduled</th>
+
+      <% if false %>
+        <th scope="col">Scheduled</th>
+      <% end %>
+
       <th colspan="2" scope="col"></th>
     </tr>
   </thead>
@@ -18,7 +22,10 @@
         <td><%= site_alert.level.capitalize %></td>
         <td><%= site_alert.message %></td>
         <td><%= site_alert.published %></td>
-        # <td><%= site_alert.scheduled %></td>
+
+        <% if false %>
+          <td><%= site_alert.scheduled %></td>
+        <% end %>
 
         <td>
           <%= link_to edit_admin_site_alert_path(site_alert)  do %>

--- a/app/views/admin/site_alerts/index.json.jbuilder
+++ b/app/views/admin/site_alerts/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @admin_site_alerts, partial: 'admin_site_alerts/admin_site_alert', as: :admin_site_alert

--- a/app/views/admin/site_alerts/new.html.erb
+++ b/app/views/admin/site_alerts/new.html.erb
@@ -1,0 +1,7 @@
+<%= link_to 'Back to site alerts list', admin_site_alerts_path %>
+
+<%= render partial: 'layouts/admin_side_pane' %>
+
+<h1>New Page</h1>
+
+<%= render 'form', site_alert: @site_alert %>

--- a/app/views/admin/site_alerts/show.html.erb
+++ b/app/views/admin/site_alerts/show.html.erb
@@ -1,0 +1,5 @@
+<%= link_to 'Back to site alerts list', admin_site_alerts_path %>
+
+<br />
+
+<%= @site_alert.display_content %>

--- a/app/views/layouts/application_v2.html.erb
+++ b/app/views/layouts/application_v2.html.erb
@@ -25,6 +25,7 @@
     <%= render "shared/staging_notice" %>
     <%= render "shared/gtm" %>
     <%= render "shared/header" %>
+    <%= render "shared/site_alerts" %>
     <main id="app">
       <% unless flash[:notice].blank? %>
         <div class="notice alert alert-info" role="alertdialog">

--- a/app/views/shared/_site_alerts.html.erb
+++ b/app/views/shared/_site_alerts.html.erb
@@ -4,7 +4,7 @@
             <div class="site-alert__message">
                 <%= sanitize alert.message %>
             </div>
-            <button type="button" class="site-alert__close button icon cross" aria-title="Close">
+            <button type="button" class="site-alert__close button icon cross-black" aria-title="Close">
                 Close
             </button>
         </div>

--- a/app/views/shared/_site_alerts.html.erb
+++ b/app/views/shared/_site_alerts.html.erb
@@ -4,8 +4,8 @@
             <div class="site-alert__message">
                 <%= sanitize alert.message %>
             </div>
-            <button type="button" class="site-alert__close">
-                X
+            <button type="button" class="site-alert__close button icon cross" aria-title="Close">
+                Close
             </button>
         </div>
     <% end %>

--- a/app/views/shared/_site_alerts.html.erb
+++ b/app/views/shared/_site_alerts.html.erb
@@ -1,0 +1,12 @@
+<div>
+    <% site_alerts.each do |alert| %>
+        <div class="site-alert site-alert--<%= alert.level %>" id="site-alert--<%= alert.machine_name %>">
+            <div class="site-alert__message">
+                <%= sanitize alert.message %>
+            </div>
+            <button type="button" class="site-alert__close">
+                X
+            </button>
+        </div>
+    <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
     resources :users, only: [:index, :update, :destroy]
     resources :transcripts, only: [:index]
     resources :flags, only: [:index]
+    resources :site_alerts
 
     get 'cms', to: 'cms#show'
     namespace :cms do

--- a/db/migrate/20230116013105_create_site_alerts.rb
+++ b/db/migrate/20230116013105_create_site_alerts.rb
@@ -1,0 +1,15 @@
+class CreateSiteAlerts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :site_alerts do |t|
+      t.string :machine_name, null: false
+      t.integer :level, null: false, default: 0
+      t.text :message
+      t.integer :user_id, null: false, default: 0
+      t.timestamp :publish_at
+      t.timestamp :unpublish_at
+
+      t.timestamps
+    end
+    add_index :site_alerts, :machine_name, unique: true
+  end
+end

--- a/db/migrate/20230116013105_create_site_alerts.rb
+++ b/db/migrate/20230116013105_create_site_alerts.rb
@@ -2,9 +2,12 @@ class CreateSiteAlerts < ActiveRecord::Migration[5.2]
   def change
     create_table :site_alerts do |t|
       t.string :machine_name, null: false
-      t.integer :level, null: false, default: 0
+      t.string :level, null: false, default: 'status'
       t.text :message
       t.integer :user_id, null: false, default: 0
+      t.boolean :published, default: false
+      t.boolean :admin_access, default: false
+      t.boolean :scheduled, default: false
       t.timestamp :publish_at
       t.timestamp :unpublish_at
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_01_004510) do
+ActiveRecord::Schema.define(version: 2023_01_16_013105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,6 +139,18 @@ ActiveRecord::Schema.define(version: 2020_10_01_004510) do
     t.string "version"
     t.integer "runtime"
     t.datetime "migrated_on"
+  end
+
+  create_table "site_alerts", force: :cascade do |t|
+    t.string "machine_name", null: false
+    t.integer "level", default: 0, null: false
+    t.text "message"
+    t.integer "user_id", default: 0, null: false
+    t.datetime "publish_at"
+    t.datetime "unpublish_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["machine_name"], name: "index_site_alerts_on_machine_name", unique: true
   end
 
   create_table "speakers", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -143,9 +143,12 @@ ActiveRecord::Schema.define(version: 2023_01_16_013105) do
 
   create_table "site_alerts", force: :cascade do |t|
     t.string "machine_name", null: false
-    t.integer "level", default: 0, null: false
+    t.string "level", default: "status", null: false
     t.text "message"
     t.integer "user_id", default: 0, null: false
+    t.boolean "published", default: false
+    t.boolean "admin_access", default: false
+    t.boolean "scheduled", default: false
     t.datetime "publish_at"
     t.datetime "unpublish_at"
     t.datetime "created_at", null: false

--- a/spec/factories/site_alerts.rb
+++ b/spec/factories/site_alerts.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :site_alert do
+    id { "MyString" }
+    message { "MyText" }
+    user_id { 1 }
+    publish_at { "2023-01-16 12:31:05" }
+    unpublish_at { "2023-01-16 12:31:05" }
+  end
+end

--- a/spec/models/site_alert_spec.rb
+++ b/spec/models/site_alert_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SiteAlert, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# AM-161

* Define first-pass attempt at integrating configurable site alerts
  * Managed like any other content item eg. Pages
  * Displays messages at top with one of 3 different levels
    * `status`
    * `warning`
    * `error`
  * Little bit of frontend JS to manage dismissal
  * **NOTE:** While there are extra fields to allow for scheduled publishing/unpublishing, they don't function yet, and have been commented out for now.
* New icon for the black cross close button

![admin list](https://user-images.githubusercontent.com/587242/212793331-df7c4be5-f176-46bc-a9a4-97591b0c41bd.png)

![editorial UI 1](https://user-images.githubusercontent.com/587242/212793406-0ff6595d-9c6a-42c2-af36-4afaec938ba2.png)

![editorial UI 2](https://user-images.githubusercontent.com/587242/212793419-7bf40371-c4af-4907-ae35-eec6cd2a4e3a.png)

![example of how the alerts look](https://user-images.githubusercontent.com/587242/212793791-4a650b7f-ae09-4115-b8fa-868d9ac0dda4.png)
