### PR TITLE
[AM-156] Introducing fuzzy search on search page

### DIFF
--- a/app/models/transcript_line.rb
+++ b/app/models/transcript_line.rb
@@ -5,7 +5,15 @@ class TranscriptLine < ApplicationRecord
   pg_search_scope :search_by_all_text, :against => [:guess_text, :original_text] # User text weighted more than original text
   pg_search_scope :search_by_original_text, :against => :original_text
   pg_search_scope :search_by_guess_text, :against => :guess_text
-
+  pg_search_scope :fuzzy_search,
+                  :against => [:guess_text, :original_text],
+                  :using => {
+                    :tsearch => { :prefix => true },
+                    :trigram => {
+                      :threshold => 0.2
+                    }
+                  },
+                  :ranked_by => ":tsearch"
   belongs_to :transcript_line_status, optional: true
   belongs_to :transcript, optional: true,touch: true
   has_many :transcript_edits

--- a/app/models/transcript_search.rb
+++ b/app/models/transcript_search.rb
@@ -25,7 +25,7 @@ class TranscriptSearch
         .joins('INNER JOIN institutions ON institutions.id = collections.institution_id')
 
       # Do the query
-      @transcripts = transcripts.search_by_all_text(options[:search])
+      @transcripts = transcripts.fuzzy_search(options[:search])
 
     # else just normal search (title, description)
     else

--- a/db/migrate/20230323024119_add_pg_search_pg_trigram_support_functions.rb
+++ b/db/migrate/20230323024119_add_pg_search_pg_trigram_support_functions.rb
@@ -1,0 +1,17 @@
+class AddPgSearchPgTrigramSupportFunctions < ActiveRecord::Migration[5.2]
+  def self.up
+    say_with_time("Adding support functions for pg_search :pg_trgm") do
+      execute <<-'SQL'
+        CREATE EXTENSION pg_trgm;
+      SQL
+    end
+  end
+
+  def self.down
+    say_with_time("Dropping support functions for pg_search :pg_trgm") do
+      execute <<-'SQL'
+        DROP EXTENSION pg_trgm;
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_16_013105) do
+ActiveRecord::Schema.define(version: 2023_03_23_024119) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   create_table "app_configs", force: :cascade do |t|

--- a/spec/models/transcript_line_spec.rb
+++ b/spec/models/transcript_line_spec.rb
@@ -149,6 +149,27 @@ RSpec.describe TranscriptLine, type: :model do
     # rubocop:enable RSpec/ExampleLength: Example has too many lines
   end
 
+  describe 'scopes' do
+    describe '#fuzzy_search' do
+      subject(:fuzzy_search) { TranscriptLine.fuzzy_search(keyword) }
+
+      let!(:jenna) do
+        FactoryBot.create :transcript_line, original_text: "And Jenna bent."
+      end
+      let(:jenni) do
+        FactoryBot.create :transcript_line, original_text: "who was Jennifer"
+      end
+
+      context 'when searching with jenna' do
+        let(:keyword) { "Jenna" }
+
+        it 'returns' do
+          expect(fuzzy_search).to contain_exactly(jenna, jenni)
+        end
+      end
+    end
+  end
+
   private
 
   def create_edit_and_recalculate(text)


### PR DESCRIPTION
**_Ticket:_** 
https://reinteractive.zendesk.com/agent/tickets/59591

**_What we did?_**
Since we want to match slightly similar search results as what was described on the ticket where we want to match `Jenna` to return both `Jenna` and `Jennifer` in search results.

We are currently using `pg_search` for searching.
The available search strategy that I could use for the described requirement above is to use `trigram`
It is an algorithm where it searches 3 consecutive combinations possible out of the search keyword.
https://www.postgresql.org/docs/current/pgtrgm.html

