### PR TITLE
Use environment variable DEPLOY_SSH_KEY for deploy SSH key

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -59,3 +59,5 @@ set :bundler_path, '/home/deploy/.rvm/wrappers/ruby-2.7.2@global/bundle'
 #     auth_methods: %w(publickey password)
 #     # password: 'please use keys'
 #   }
+
+ssh_options[:keys] ||= ENV['DEPLOY_SSH_KEY'] if ENV['DEPLOY_SSH_KEY']

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -58,3 +58,5 @@ set :branch, ENV['BRANCH'] || 'develop'
 #     auth_methods: %w(publickey password)
 #     # password: 'please use keys'
 #   }
+
+ssh_options[:keys] ||= ENV['DEPLOY_SSH_KEY'] if ENV['DEPLOY_SSH_KEY']


### PR DESCRIPTION
So we can select it as part of deployment automation.