### PR TITLE
[AM-193] Add gem to fix auth error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ gem "devise", "~> 4.9.0"
 gem "oauth2", github: "oauth-xx/oauth2", ref: "v2.0.1"
 gem "omniauth-facebook", "~> 9.0.0"
 gem "omniauth-google-oauth2", "< 1.1.1"
+gem "omniauth-rails_csrf_protection"
 
 # Beef up security.
 gem "invisible_captcha", "~> 0.12.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,6 +518,9 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     optimist (3.0.1)
     orm_adapter (0.5.0)
     os (1.1.4)
@@ -828,6 +831,7 @@ DEPENDENCIES
   oauth2!
   omniauth-facebook (~> 9.0.0)
   omniauth-google-oauth2 (< 1.1.1)
+  omniauth-rails_csrf_protection
   paper_trail (~> 10.3.1)
   pg (~> 1.1.4)
   pg_search (~> 2.1.4)


### PR DESCRIPTION
# AM-193

Add `omniauth-rails_csrf_protection` to fix auth as per https://stackoverflow.com/questions/66086606/could-not-authenticate-you-from-googleoauth2-because-authenticity-error and https://github.com/decidim/decidim/issues/9048