### PR TITLE
[BUGFIX] Bugsnag is not reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -184,7 +184,7 @@ group :staging, :production do
 end
 
 # tracking errors
-gem "bugsnag", "~> 6.11.1"
+gem "bugsnag"
 gem "draper", "~> 4.0.2"
 gem 'nokogiri', '1.12.5'
 gem "sanitize", "~> 5.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       autoprefixer-rails (>= 6.0.3)
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)
-    bugsnag (6.11.1)
+    bugsnag (6.26.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     byebug (11.0.1)
@@ -784,7 +784,7 @@ DEPENDENCIES
   bcrypt_pbkdf (~> 1.1)
   bootsnap
   bootstrap (~> 4.1.1)
-  bugsnag (~> 6.11.1)
+  bugsnag
   byebug (~> 11.0.0)
   capistrano (~> 3.17)
   capistrano-bundler (~> 2.0)


### PR DESCRIPTION
I found out that the Bugsnag has no data.
2 issues where found
- Environment variable for bugsnag api key is not set
- Bugsnag current gem version is causing an exception `Bugsnag middleware error: no implicit conversion of Hash into String`

Solutions:
- Set environment variable in both staging and prod
- Upgrade bugsnag gem version

After the fix
<img width="853" alt="Screenshot 2023-12-01 at 3 51 55 PM" src="https://github.com/slnsw/amplify/assets/4254020/45317c73-d65f-410e-a081-1f5e536d6656">

