### PR TITLE
Attempting to fix slowness issue on search page.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -184,7 +184,7 @@ group :staging, :production do
 end
 
 # tracking errors
-gem "bugsnag", "~> 6.11.1"
+gem "bugsnag"
 gem "draper", "~> 4.0.2"
 gem 'nokogiri', '1.12.5'
 gem "sanitize", "~> 5.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       autoprefixer-rails (>= 6.0.3)
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)
-    bugsnag (6.11.1)
+    bugsnag (6.26.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     byebug (11.0.1)
@@ -784,7 +784,7 @@ DEPENDENCIES
   bcrypt_pbkdf (~> 1.1)
   bootsnap
   bootstrap (~> 4.1.1)
-  bugsnag (~> 6.11.1)
+  bugsnag
   byebug (~> 11.0.0)
   capistrano (~> 3.17)
   capistrano-bundler (~> 2.0)

--- a/app/assets/stylesheets/application_v2.scss
+++ b/app/assets/stylesheets/application_v2.scss
@@ -28,6 +28,7 @@
 @import 'components/collections';
 @import 'components/users';
 @import 'components/messages';
+@import "components/will_paginate";
 
 @import 'base/trumps';
 @import 'select2';

--- a/app/controllers/concerns/home_search.rb
+++ b/app/controllers/concerns/home_search.rb
@@ -16,8 +16,11 @@ module HomeSearch
 
   def build_params
     sort_params.reject do |_key, value|
-      value.blank? ||
-        (value&.first && (value.first.blank? || value.first == "0"))
+      return true if value.blank?
+
+      if value.is_a?(Array)
+        value.first.blank? || value.first == '0'
+      end
     end
   end
 

--- a/app/controllers/concerns/home_search.rb
+++ b/app/controllers/concerns/home_search.rb
@@ -7,6 +7,8 @@ module HomeSearch
     params.permit(
       :sort_by, :search,
       :institution,
+      :page,
+      :per_page,
       themes: [],
       collections: []
     ).reject { |_, v| v.blank? }

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,7 +7,7 @@ class SearchController < ApplicationController
 
   def index
     @page_title = "Search"
-
+    build_params[:page] ||= 1
     @build_params = build_params
     @transcripts = TranscriptSearch.new(build_params).transcripts
     @themes = Theme.all.order(name: :asc)

--- a/app/models/transcript_line.rb
+++ b/app/models/transcript_line.rb
@@ -5,7 +5,12 @@ class TranscriptLine < ApplicationRecord
   pg_search_scope :search_by_all_text, :against => [:guess_text, :original_text] # User text weighted more than original text
   pg_search_scope :search_by_original_text, :against => :original_text
   pg_search_scope :search_by_guess_text, :against => :guess_text
-  pg_search_scope :fuzzy_search, :against => [:guess_text, :original_text], using: { dmetaphone: {} }
+  pg_search_scope :fuzzy_search, against: :guess_text,
+                  using: {
+                    trigram: {
+                      threshold: 0.1
+                    }
+                  }
   belongs_to :transcript_line_status, optional: true
   belongs_to :transcript, optional: true,touch: true
   has_many :transcript_edits

--- a/app/models/transcript_search.rb
+++ b/app/models/transcript_search.rb
@@ -25,7 +25,7 @@ class TranscriptSearch
         .joins('INNER JOIN institutions ON institutions.id = collections.institution_id')
 
       # Do the query
-      # @transcripts = transcripts.fuzzy_search(options[:search])
+      @transcripts = @transcripts.fuzzy_search(options[:search])
 
     # else just normal search (title, description)
     else

--- a/app/models/transcript_search.rb
+++ b/app/models/transcript_search.rb
@@ -3,8 +3,8 @@ class TranscriptSearch
 
   def initialize(options)
     options[:page] ||= 1
+    options[:per_page] ||= 30
     project = Project.getActive
-    per_page = 500
     per_page = project[:data]["transcriptsPerPage"].to_i if project && project[:data]["transcriptsPerPage"]
     sort_order = "ASC"
     sort_order = "DESC" if options[:order].present? && options[:order].downcase=="desc"
@@ -25,7 +25,7 @@ class TranscriptSearch
         .joins('INNER JOIN institutions ON institutions.id = collections.institution_id')
 
       # Do the query
-      @transcripts = transcripts.fuzzy_search(options[:search])
+      # @transcripts = transcripts.fuzzy_search(options[:search])
 
     # else just normal search (title, description)
     else
@@ -38,8 +38,7 @@ class TranscriptSearch
 
     @transcripts = transcripts.where("transcripts.published_at IS NOT NULL")
     @transcripts = transcripts.where("collections.published_at IS NOT NULL")
-    # Paginate
-    @transcripts = transcripts.where("transcripts.project_uid = :project_uid", {project_uid: ENV['PROJECT_ID']}).paginate(:page => options[:page], :per_page => per_page)
+    @transcripts = transcripts.where("transcripts.project_uid = :project_uid", {project_uid: ENV['PROJECT_ID']})
 
     # Check for collection filter
     @transcripts = transcripts.where("collections.title in (?)", options[:collections]) if options[:collections].present?
@@ -54,5 +53,8 @@ class TranscriptSearch
 
     # Check for sort
     @transcripts = transcripts.order("transcripts.#{sort_by} #{sort_order}")
+
+    # paginate
+    @transcripts = @transcripts.paginate(:page => options[:page], :per_page => options[:per_page])
   end
 end

--- a/app/views/search/_transcript_list.html.erb
+++ b/app/views/search/_transcript_list.html.erb
@@ -25,4 +25,5 @@
     </div>
   </div>
 <% end %>
+<%= will_paginate transcripts %>
 </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -14,5 +14,5 @@
 
 <%= render partial: 'search/filters' %>
 <section class="search_results">
-    <%= render partial: 'search/transcript_list', locals: { transcripts: (@transcripts || []) } %>
+  <%= render partial: 'search/transcript_list', locals: { transcripts: (@transcripts || []) } %>
 </section>


### PR DESCRIPTION
Description:

The goal of this PR is to attempt to fix the slowness issue on the search page.
- We replace the fuzzy search approach Double Metaphone sound-like search with the trigram approach.
- Currently, we search on 2 fields, `original_text` and `guess_text`. On this attempt, we want to to search just the `guess text`