### PR TITLE
Looker Studio integration

### DIFF
--- a/app/controllers/admin/analytics_controller.rb
+++ b/app/controllers/admin/analytics_controller.rb
@@ -2,9 +2,11 @@ class Admin::AnalyticsController < AdminController
   before_action :authenticate_staff!
 
   def index
+    raise ActionController::RoutingError.new('Not Found') unless current_user.institution.present?
+    
     @institution = current_user.institution
     uri = URI(ENV['LOOKER_STUDIO_IFRAME_URL'])
-    uri.query = "params[df235]=include%E2%80%800%E2%80%80PT%E2%80%80%2F#{@institution.guid}"
+    uri.query="params={'df235':'include%25EE%2580%25800%25EE%2580%2580PT%25EE%2580%2580%252F#{@institution.guid}}"
     @analytics_url = uri.to_s
   end
 end

--- a/app/controllers/admin/analytics_controller.rb
+++ b/app/controllers/admin/analytics_controller.rb
@@ -3,10 +3,10 @@ class Admin::AnalyticsController < AdminController
 
   def index
     raise ActionController::RoutingError.new('Not Found') unless current_user.institution.present?
-    
+
     @institution = current_user.institution
     uri = URI(ENV['LOOKER_STUDIO_IFRAME_URL'])
-    uri.query="params={'df235':'include%25EE%2580%25800%25EE%2580%2580PT%25EE%2580%2580%252F#{@institution.guid}}"
+    uri.query=URI.encode_www_form_component("params={'df235':'include%25EE%2580%25800%25EE%2580%2580PT%25EE%2580%2580%252F#{@institution.guid}}")
     @analytics_url = uri.to_s
   end
 end

--- a/app/controllers/admin/analytics_controller.rb
+++ b/app/controllers/admin/analytics_controller.rb
@@ -1,0 +1,10 @@
+class Admin::AnalyticsController < AdminController
+  before_action :authenticate_staff!
+
+  def index
+    @institution = current_user.institution
+    uri = URI(ENV['LOOKER_STUDIO_IFRAME_URL'])
+    uri.query = "params[df235]=include%E2%80%800%E2%80%80PT%E2%80%80%2F#{@institution.guid}"
+    @analytics_url = uri.to_s
+  end
+end

--- a/app/controllers/api/institutions/guids_controller.rb
+++ b/app/controllers/api/institutions/guids_controller.rb
@@ -1,0 +1,27 @@
+class Api::Institutions::GuidsController < ActionController::Base
+  before_action :authenticate_request
+
+  def index
+    data = Institution.all.select(:slug, :guid).map { |i| { UID: i.slug, GUID: i.guid } }
+
+    render json: data
+  end
+
+  private
+
+  def authenticate_request
+    token = extract_bearer_token
+    if !token
+      render json: { error: 'Unauthorized' }, status: :unauthorized
+    end
+  end
+
+  def extract_bearer_token
+    auth_header = request.headers['Authorization']
+    if auth_header && auth_header.start_with?('Bearer ')
+      auth_header.split(' ').last
+    else
+      nil
+    end
+  end
+end

--- a/app/controllers/api/institutions/guids_controller.rb
+++ b/app/controllers/api/institutions/guids_controller.rb
@@ -11,7 +11,7 @@ class Api::Institutions::GuidsController < ActionController::Base
 
   def authenticate_request
     token = extract_bearer_token
-    if !token
+    if token != ENV['LOOKER_STUDIO_EXTERNAL_SECRET']
       render json: { error: 'Unauthorized' }, status: :unauthorized
     end
   end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -6,6 +6,7 @@ module AdminHelper
       OpenStruct.new(path: admin_users_path, icon: "users", text: "User", type: 2),
       OpenStruct.new(path: admin_cms_path, icon: "list-ul", text: "CMS", type: 2),
       OpenStruct.new(path: admin_summary_index_path, icon: "pie-chart", text: "Analytics", type: 1),
+      OpenStruct.new(path: admin_analytics_path, icon: "pie-chart", text: "Google Analytics", type: 4),
       OpenStruct.new(path: admin_institutions_path, icon: "university", text: "Institutions", type: 2),
       OpenStruct.new(path: admin_pages_path, icon: "file", text: "Pages", type: 4),
       OpenStruct.new(path: admin_themes_path, icon: "paint-brush", text: "Themes", type: 4),

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -61,6 +61,7 @@ class Institution < ApplicationRecord
     self.max_line_edits = min_lines_for_consensus
     self.min_lines_for_consensus_no_edits = min_lines_for_consensus
     self.min_percent_consensus = min_lines_for_consensus.to_f / (max_line_edits + 1).to_f
+    self.guid = SecureRandom.uuid unless guid.present?
   end
 
   def self.all_institution_disk_usage

--- a/app/views/admin/analytics/index.html.erb
+++ b/app/views/admin/analytics/index.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: 'layouts/admin_side_pane' %>
+<object data="<%= @analytics_url %>" style="width: 100%; height: 100%;"></object>
+</iframe>

--- a/app/views/admin/analytics/index.html.erb
+++ b/app/views/admin/analytics/index.html.erb
@@ -1,3 +1,2 @@
 <%= render partial: 'layouts/admin_side_pane' %>
-<object data="<%= @analytics_url %>" style="width: 100%; height: 100%;"></object>
-</iframe>
+<iframe src="<%= @analytics_url %>" style="width: 100%; height: 100%;"></iframe>

--- a/app/views/layouts/_flash_notice.html.erb
+++ b/app/views/layouts/_flash_notice.html.erb
@@ -1,11 +1,11 @@
-<div class="row">
-  <div class="col-md-12">
-    <br />
-    <% if flash[:notice].present? %>
-        <div class="alert-primary" role="alert">
-          <%= flash[:notice] %>
-        </div>
-    <% end %>
-    <br />
+<% if flash[:notice].present? %>
+  <div class="row">
+    <div class="col-md-12">
+      <br />
+      <div class="alert-primary" role="alert">
+        <%= flash[:notice] %>
+      </div>   
+      <br />
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/layouts/_flash_notice.html.erb
+++ b/app/views/layouts/_flash_notice.html.erb
@@ -4,7 +4,7 @@
       <br />
       <div class="alert-primary" role="alert">
         <%= flash[:notice] %>
-      </div>   
+      </div>
       <br />
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,12 @@ require 'sidekiq/web'
 require 'sidekiq/cron/web'
 
 Rails.application.routes.draw do
+  namespace :api do
+    namespace :institutions do
+      resources :guids, only: [:index]
+    end
+  end
+
   namespace :admin do
     resources :institutions do
       resources :transcription_conventions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
         get :details
       end
     end
+    resources :analytics, only: [:index] do
+    end
   end
   resources :flags, only: [:index, :show, :create]
   resources :transcript_speaker_edits, only: [:create]

--- a/db/migrate/20240709023226_add_guid_to_institutions.rb
+++ b/db/migrate/20240709023226_add_guid_to_institutions.rb
@@ -1,0 +1,9 @@
+class AddGuidToInstitutions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :institutions, :guid, :string
+
+    Institution.where(guid: nil).find_each do |institution|
+      institution.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_21_044933) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_09_023226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -109,6 +109,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_21_044933) do
     t.string "line_display_method", default: "guess"
     t.integer "super_user_hiearchy", default: 50
     t.boolean "hidden", default: false
+    t.string "guid"
     t.index ["slug"], name: "index_institutions_on_slug"
   end
 


### PR DESCRIPTION
Whats this change do?

Add an endpoint to return GUIDs in each of the institutions

**Request**
```
> GET /api/institutions/guids HTTP/1.1
> Host: localhost:3000
> Authorization: Bearer xxx\
```
**Response**
```
[
	{
		"UID": "statelibrarynsw",
		"GUID": "160c6f3c-1b4c-476a-914e-xxxxx"
	},
	...
]
```

It also adds a new page in the admin port to view looker studio 
http://localhost:3000/admin/analytics
[Watch DEMO](https://github.com/slnsw/amplify/assets/4254020/2f379487-9430-478b-a701-f1f2f11de6c5)

Prerequisite before deployment:
```
LOOKER_STUDIO_IFRAME_URL: https://lookerstudio.google.com/embed/reporting/94020631-6a0a-400c-a1b2-afb8344812fa/page/moi4
LOOKER_STUDIO_EXTERNAL_SECRET:  <generate a secret key for production use>
```

It also requires running rails migration