### PR TITLE
addressed amendments

### DIFF
--- a/app/controllers/admin/analytics_controller.rb
+++ b/app/controllers/admin/analytics_controller.rb
@@ -6,7 +6,7 @@ class Admin::AnalyticsController < AdminController
 
     @institution = current_user.institution
     uri = URI(ENV['LOOKER_STUDIO_IFRAME_URL'])
-    uri.query=URI.encode_www_form_component("params={'df235':'include%25EE%2580%25800%25EE%2580%2580PT%25EE%2580%2580%252F#{@institution.guid}}")
+    uri.query = URI.encode_www_form({ guid: @institution.guid, domain: ENV['DOMAIN'] })
     @analytics_url = uri.to_s
   end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -6,7 +6,7 @@ module AdminHelper
       OpenStruct.new(path: admin_users_path, icon: "users", text: "User", type: 2),
       OpenStruct.new(path: admin_cms_path, icon: "list-ul", text: "CMS", type: 2),
       OpenStruct.new(path: admin_summary_index_path, icon: "pie-chart", text: "Analytics", type: 1),
-      OpenStruct.new(path: admin_analytics_path, icon: "pie-chart", text: "Google Analytics", type: 4),
+      OpenStruct.new(path: admin_analytics_path, icon: "pie-chart", text: "Google Analytics", type: 4, hide: current_user&.institution.nil?),
       OpenStruct.new(path: admin_institutions_path, icon: "university", text: "Institutions", type: 2),
       OpenStruct.new(path: admin_pages_path, icon: "file", text: "Pages", type: 4),
       OpenStruct.new(path: admin_themes_path, icon: "paint-brush", text: "Themes", type: 4),
@@ -15,7 +15,7 @@ module AdminHelper
       OpenStruct.new(path: "/page/user_guide", icon: "question-circle", text: "User Guide", type: 2),
       OpenStruct.new(path: "/sidekiq", icon: "tasks", text: "Background queue", type: 4),
     ]
-    list.reject { |i| i.type > user_type }
+    list.reject { |i| i.type > user_type || i.hide }
   end
   # rubocop:enable Metrics/LineLength, Metrics/MethodLength, Metrics/AbcSize
 


### PR DESCRIPTION
- Hides the Google Analytics tab when admin is not associated with any institution
- Update the integration URL and parameters

**Prerequisite**

the following environment variables need to be added to staging and production

### staging environment
```
LOOKER_STUDIO_IFRAME_URL=https://ih.pivotanalytics.com.au/webhook/xxx
DOMAIN=stage.amplify.gov.au
```

## production environment
```
LOOKER_STUDIO_IFRAME_URL=https://ih.pivotanalytics.com.au/webhook/xxx
DOMAIN=amplify.gov.au
```

### Important Notes

Seeing the error as the image below indicates that the `pivotanalytics` has no record of the GUID being passed to the iframe. There 2 things that might cause this
- GUIDs is not being pulled yet by them
- GUIDs for institution endpoint is failing

![image](https://github.com/user-attachments/assets/c4788223-abe6-4193-989a-a15942056819)

Seeing the logs from pivotanalytics side will give us better info on whats going on.