### PR TITLE
Admin transcribing role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ app/files/uploads/*
 
 # Database,
 *.sql.gz
+.tool-versions

--- a/app/controllers/admin/profiles_controller.rb
+++ b/app/controllers/admin/profiles_controller.rb
@@ -1,0 +1,24 @@
+class Admin::ProfilesController < ApplicationController
+  include Pundit
+  layout "admin"
+
+  def index
+    @user_role = current_user.user_role
+  end
+
+  def update
+    update_transcribing_role if params.dig(:user_role, :commit) == "update_transcribing_role"
+
+    redirect_to admin_profiles_path
+  end
+
+  private
+
+  def update_transcribing_role
+    return unless current_user.admin?
+
+    transcribing_role = params.dig(:user_role, :transcribing_role)
+    flash[:notice] = "Admin's transcribing role has been updated to #{transcribing_role}."
+    current_user.user_role.update(transcribing_role: params.dig(:user_role, :transcribing_role))
+  end
+end

--- a/app/controllers/transcripts_controller.rb
+++ b/app/controllers/transcripts_controller.rb
@@ -108,6 +108,7 @@ class TranscriptsController < ApplicationController
 
   def set_transcript_for_show
     @transcript = TranscriptService.find_by_uid_for_admin(params[:id], logged_in_user)
+    raise ActiveRecord::RecordNotFound unless @transcript.present?
   end
 
   def transcript_params

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -10,10 +10,17 @@ class Flag < ApplicationRecord
         WHEN users.id IS null THEN \'anonymous user\'
         WHEN user_roles.name IS NOT null THEN user_roles.name
         ELSE \'registered user\'
-      END as user_name, COALESCE(user_roles.name, \'guest\') as user_role, COALESCE(user_roles.hiearchy, 0) as user_hiearchy')
-      .joins('INNER JOIN flag_types ON flags.flag_type_id = flag_types.id LEFT OUTER JOIN users ON users.id = flags.user_id LEFT OUTER JOIN user_roles ON user_roles.id = users.user_role_id')
-      .where("flags.transcript_line_id = :transcript_line_id AND flags.is_deleted = :is_deleted AND flag_types.category = :category",
-      {transcript_line_id: transcript_line_id, is_deleted: 0, category: 'error'})
+      END as user_name,
+      COALESCE(user_roles.name, \'guest\') as user_role,
+      COALESCE(user_roles.hiearchy, 0) as user_hiearchy,
+      COALESCE(user_roles.transcribing_role, \'registered_user\') as transcribing_role')
+      .joins('INNER JOIN flag_types ON flags.flag_type_id = flag_types.id
+              LEFT OUTER JOIN users ON users.id = flags.user_id
+              LEFT OUTER JOIN user_roles ON user_roles.id = users.user_role_id')
+      .where("flags.transcript_line_id = :transcript_line_id
+              AND flags.is_deleted = :is_deleted
+              AND flag_types.category = :category",
+              { transcript_line_id: transcript_line_id, is_deleted: 0, category: 'error' })
   end
 
   def self.getByTranscriptSession(transcript_id, session_id)

--- a/app/models/transcript.rb
+++ b/app/models/transcript.rb
@@ -589,6 +589,8 @@ class Transcript < ApplicationRecord
 
   # If the image has a cropped version we display it, otherwise we display the original image.
   def image_cropped_thumb_url
+    return nil unless self&.image_url.present?
+
     crop_x.present? ? image_url(:cropped_thumb) : (image_url || collection.image_url)
   end
 end

--- a/app/models/transcript_edit.rb
+++ b/app/models/transcript_edit.rb
@@ -16,8 +16,12 @@ class TranscriptEdit < ApplicationRecord
 
   def self.getByLine(transcript_line_id)
     TranscriptEdit
-      .select('transcript_edits.*, COALESCE(user_roles.name, \'guest\') as user_role, COALESCE(user_roles.hiearchy, 0) as user_hiearchy')
-      .joins('LEFT OUTER JOIN users ON users.id = transcript_edits.user_id LEFT OUTER JOIN user_roles ON user_roles.id = users.user_role_id')
+      .select('transcript_edits.*,
+      COALESCE(user_roles.name, \'guest\') as user_role,
+      COALESCE(user_roles.hiearchy, 0) as user_hiearchy,
+      COALESCE(user_roles.transcribing_role, \'registered_user\') as transcribing_role')
+      .joins('LEFT OUTER JOIN users ON users.id = transcript_edits.user_id
+              LEFT OUTER JOIN user_roles ON user_roles.id = users.user_role_id')
       .where(transcript_line_id: transcript_line_id, is_deleted: 0)
   end
 

--- a/app/models/transcript_speaker_edit.rb
+++ b/app/models/transcript_speaker_edit.rb
@@ -10,8 +10,12 @@ class TranscriptSpeakerEdit < ApplicationRecord
 
   def self.getByLine(transcript_line_id)
     TranscriptSpeakerEdit
-      .select('transcript_speaker_edits.*, COALESCE(user_roles.name, \'guest\') as user_role, COALESCE(user_roles.hiearchy, 0) as user_hiearchy')
-      .joins('LEFT OUTER JOIN users ON users.id = transcript_speaker_edits.user_id LEFT OUTER JOIN user_roles ON user_roles.id = users.user_role_id')
+      .select('transcript_speaker_edits.*,
+      COALESCE(user_roles.name, \'guest\') as user_role,
+      COALESCE(user_roles.hiearchy, 0) as user_hiearchy,
+      COALESCE(user_roles.transcribing_role, \'registered_user\') as transcribing_role')
+      .joins('LEFT OUTER JOIN users ON users.id = transcript_speaker_edits.user_id
+              LEFT OUTER JOIN user_roles ON user_roles.id = users.user_role_id')
       .where(transcript_line_id: transcript_line_id)
   end
 end

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -4,6 +4,8 @@ class UserRole < ApplicationRecord
   # any user role that is <= 3 consider as public users (guest and registred)
   MIN_STAFF_LEVEL = 3
 
+  enum transcribing_role: { admin: 'admin', registered_user: 'registered_user' }
+
   def self.getAll
     UserRole.order(:hiearchy)
   end

--- a/app/views/admin/profiles/_update_transcribing_role_form.html.erb
+++ b/app/views/admin/profiles/_update_transcribing_role_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_for @user_role, url: admin_profile_path(id: current_user), html: { method: :patch } do |f| %>
+  <p>Active role for transcribing:</p>
+
+  <div>
+    <%= f.radio_button :transcribing_role, "admin" %>
+    <%= f.label :transcribing_role, "Admin user", value: "admin" %>
+  </div>
+
+  <div>
+    <%= f.radio_button :transcribing_role, "registered_user" %>
+    <%= f.label :transcribing_role, "Registered user", value: "registered" %>
+  </div>
+
+  <p>
+    As an Admin user, any updates you make to transcripts are immediately approved and do not go through the usual consensus workflow.
+    If you choose to change your role to Registered user, all content updates will use the consensus workflow.
+  </p>
+
+  <div>
+    <%= f.hidden_field :commit, value: "update_transcribing_role" %>
+    <%= f.submit "Save Profile", class: "btn btn-primary" %>
+    <%= link_to "Cancel", admin_profiles_path, class: "btn" %>
+  </div>
+<% end %>

--- a/app/views/admin/profiles/index.html.erb
+++ b/app/views/admin/profiles/index.html.erb
@@ -1,0 +1,3 @@
+<h2>Edit My Profile</h2>
+
+<%= render partial: "admin/profiles/update_transcribing_role_form" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -48,6 +48,7 @@
             <%= link_to "Dashboard", "/dashboard", class: "dropdown-link", 'data-menu-level': 2 %>
             <% if current_user.staff? %>
               <%= link_to "Admin Portal", "/admin", class: "dropdown-link", 'data-menu-level': 2 %>
+              <%= link_to "Edit My Profiles", admin_profiles_path, class: "dropdown-link", 'data-menu-level': 2 %>
             <% end %>
             <%= link_to 'Sign out', destroy_user_session_path, class: "dropdown-link", 'data-menu-level': 2 %>
           <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
+    resources :profiles, only: [:index, :update]
+
     resources :institutions do
       resources :transcription_conventions
     end

--- a/db/migrate/20250214073213_add_hierarchy_bypass_to_user_role.rb
+++ b/db/migrate/20250214073213_add_hierarchy_bypass_to_user_role.rb
@@ -1,0 +1,5 @@
+class AddHierarchyBypassToUserRole < ActiveRecord::Migration[7.0]
+  def change
+    add_column :user_roles, :transcribing_role, :string, default: "registered_user"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_09_023226) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_14_073213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -345,8 +345,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_09_023226) do
     t.string "name", default: "", null: false
     t.integer "hiearchy", default: 0, null: false
     t.string "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "transcribing_role", default: "registered_user"
     t.index ["name"], name: "index_user_roles_on_name", unique: true
   end
 

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -14,6 +14,14 @@ FactoryBot.define do
       association :user_role, factory: [:user_role, :admin]
     end
 
+    trait :admin_with_admin_transcribing_role do
+      association :user_role, factory: [:user_role, :admin_with_admin_transcribing_role]
+    end
+
+    trait :admin_with_registed_user_transcribing_role do
+      association :user_role, factory: [:user_role, :admin_with_registed_user_transcribing_role]
+    end
+
     trait :moderator do
       association :user_role, factory: [:user_role, :moderator]
     end

--- a/spec/factories/user_role.rb
+++ b/spec/factories/user_role.rb
@@ -10,6 +10,20 @@ FactoryBot.define do
       description { 'Administrator has all privileges' }
     end
 
+    trait :admin_with_admin_transcribing_role do
+      name { 'admin' }
+      transcribing_role { 'admin' }
+      hiearchy { 100 }
+      description { 'Administrator has all privileges' }
+    end
+
+    trait :admin_with_registed_user_transcribing_role do
+      name { 'admin' }
+      transcribing_role { 'registered_user' }
+      hiearchy { 100 }
+      description { 'Administrator has all privileges' }
+    end
+
     trait :moderator do
       name { 'moderator' }
       hiearchy { 50 }

--- a/spec/models/transcript_line_spec.rb
+++ b/spec/models/transcript_line_spec.rb
@@ -53,8 +53,31 @@ RSpec.describe TranscriptLine, type: :model do
       end
     end
 
+    context "when with admin with admin transcribing role" do
+      let!(:min_lines_for_consensus) { 2 }
+      let(:admin) { create(:user, :admin_with_admin_transcribing_role) }
+
+      it "bypass concensus, status is set to completed" do
+        FactoryBot.create :transcript_edit, transcript: transcript, transcript_line: transcript_line, text: "first", user_id: admin.id
+        re_calculate
+        expect(transcript_line.transcript_line_status.name).to eq("completed")
+      end
+    end
+
+    context "when with admin with registed user transcribing role" do
+      let!(:min_lines_for_consensus) { 2 }
+      let(:admin) { create(:user, :admin_with_registed_user_transcribing_role) }
+
+      it "bypass concensus, status is set to completed" do
+        FactoryBot.create :transcript_edit, transcript: transcript, transcript_line: transcript_line, text: "first", user_id: admin.id
+        re_calculate
+        expect(transcript_line.transcript_line_status.name).to eq("editing")
+      end
+    end
+
     context "when verifying with 2 min_lines_for_consensus" do
       let!(:min_lines_for_consensus) { 2 }
+      let(:admin) { create(:user, :admin_with_admin_transcribing_role) }
 
       it "third selection should make the line as completed" do
         create_edit_and_recalculate("first")
@@ -67,7 +90,7 @@ RSpec.describe TranscriptLine, type: :model do
         expect(transcript_line.transcript_line_status.name).to eq("completed")
 
         create_edit_and_recalculate("second")
-        expect(transcript_line.text).to eq("first")
+        expect(transcript_line.text).to eq("second")
 
         FactoryBot.create :transcript_edit, transcript: transcript, transcript_line: transcript_line, text: "third", user_id: admin.id
         re_calculate


### PR DESCRIPTION
This PR does the following
- Allows admin to define its user transcribing role
  - admin - Consensus is not required when transcribing
  - registered_user - Follows the consensus logic
- Edit profile page