### PR TITLE
Update CSP Policy to Address Specific Violations

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,6 +1,6 @@
 Rails.application.config.content_security_policy do |policy|
   policy.default_src  :self, :https
-  policy.font_src     :self, :https, :data
+  policy.font_src     :self, :https, :data, 'chrome-extension:'
   policy.img_src      :self, 'blob:', 'data:',
                       'https://*.google-analytics.com',
                       'https://*.analytics.google.com',
@@ -9,6 +9,7 @@ Rails.application.config.content_security_policy do |policy|
                       'https://*.google.com',
                       'https://*.google.com.au',
                       'https://graph.facebook.com',
+                      'http://graph.facebook.com', # Allow http for Facebook images
                       :https,
                       :data
 


### PR DESCRIPTION
## Summary

This PR updates the Content Security Policy (CSP) configuration to address specific violations logged in the `csp_violations.log` file. The changes focus on resolving issues related to blocked Facebook images and browser extension font files.

## Changes Made

**img-src Directive**
- Added `http://graph.facebook.com` to allow Facebook profile images served over HTTP.
- This resolves violations where Facebook images were blocked (e.g., `http://graph.facebook.com/10154757275959288/picture`).

**font-src Directive**
- Added `chrome-extension:` to allow font files loaded by browser extensions.
- This resolves violations caused by blocked font files from extensions (e.g., `chrome-extension://jcmcbmdmfmelmlelagelpfhmohipjjia/Inter-Medium.woff2`).

## Testing

- Verified that the updated CSP policy resolves the reported violations in a development environment.
- Ensured no new CSP violations are introduced by these changes.

## Next Steps

- Monitor the `csp_violations.log` file post-deployment to confirm the effectiveness of these updates.
- Continue refining the CSP policy as new violations are identified.
