### PR TITLE
Migrate from String Based -> Integer Based Enums

### DIFF
--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -13,7 +13,7 @@ class Flag < ApplicationRecord
       END as user_name,
       COALESCE(user_roles.name, \'guest\') as user_role,
       COALESCE(user_roles.hiearchy, 0) as user_hiearchy,
-      COALESCE(user_roles.transcribing_role, \'registered_user\') as transcribing_role')
+      COALESCE(user_roles.transcribing_role, 0) as transcribing_role')
       .joins('INNER JOIN flag_types ON flags.flag_type_id = flag_types.id
               LEFT OUTER JOIN users ON users.id = flags.user_id
               LEFT OUTER JOIN user_roles ON user_roles.id = users.user_role_id')

--- a/app/models/site_alert.rb
+++ b/app/models/site_alert.rb
@@ -1,6 +1,5 @@
 class SiteAlert < ApplicationRecord
   has_paper_trail
 
-  # TODO: Convert to integer-based enum
-  enum :level, { status: 'status', warning: 'warning', error: 'error' }
+  enum :level, { status: 0, warning: 1, error: 2 }
 end

--- a/app/models/transcript.rb
+++ b/app/models/transcript.rb
@@ -21,10 +21,9 @@ class Transcript < ApplicationRecord
   pg_search_scope :search_default, :against => [:title, :description]
   pg_search_scope :search_by_title, :against => :title
 
-  # TODO: Convert to integer-based enum
   enum :transcript_type, { voicebase: 0, manual: 1, azure: 2 }
 
-  enum :process_status, { started: 'started', completed: 'completed', failed: 'failed' }, prefix: :process
+  enum :process_status, { started: 0, completed: 1, failed: 2 }, prefix: :process
 
   scope :voicebase_processing_pending, -> { voicebase.where(process_completed_at: nil) }
   scope :not_picked_up_for_voicebase_processing, -> { voicebase.where.not(process_started_at: nil) }

--- a/app/models/transcript_edit.rb
+++ b/app/models/transcript_edit.rb
@@ -19,7 +19,7 @@ class TranscriptEdit < ApplicationRecord
       .select('transcript_edits.*,
       COALESCE(user_roles.name, \'guest\') as user_role,
       COALESCE(user_roles.hiearchy, 0) as user_hiearchy,
-      COALESCE(user_roles.transcribing_role, \'registered_user\') as transcribing_role')
+      COALESCE(user_roles.transcribing_role, 0) as transcribing_role')
       .joins('LEFT OUTER JOIN users ON users.id = transcript_edits.user_id
               LEFT OUTER JOIN user_roles ON user_roles.id = users.user_role_id')
       .where(transcript_line_id: transcript_line_id, is_deleted: 0)

--- a/app/models/transcript_speaker_edit.rb
+++ b/app/models/transcript_speaker_edit.rb
@@ -13,7 +13,7 @@ class TranscriptSpeakerEdit < ApplicationRecord
       .select('transcript_speaker_edits.*,
       COALESCE(user_roles.name, \'guest\') as user_role,
       COALESCE(user_roles.hiearchy, 0) as user_hiearchy,
-      COALESCE(user_roles.transcribing_role, \'registered_user\') as transcribing_role')
+      COALESCE(user_roles.transcribing_role, 0) as transcribing_role')
       .joins('LEFT OUTER JOIN users ON users.id = transcript_speaker_edits.user_id
               LEFT OUTER JOIN user_roles ON user_roles.id = users.user_role_id')
       .where(transcript_line_id: transcript_line_id)

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -4,8 +4,7 @@ class UserRole < ApplicationRecord
   # any user role that is <= 3 consider as public users (guest and registred)
   MIN_STAFF_LEVEL = 3
 
-  # TODO: Convert to integer-based enum
-  enum :transcribing_role, { admin: 'admin', registered_user: 'registered_user' }
+  enum :transcribing_role, { registered_user: 0, admin: 1 }
 
   def self.getAll
     UserRole.order(:hiearchy)

--- a/app/views/admin/site_alerts/_form.html.erb
+++ b/app/views/admin/site_alerts/_form.html.erb
@@ -3,7 +3,7 @@
   
     <div class="form-group">
       <%= form.label :level %>
-      <%= form.select :level, options_for_select(SiteAlert.levels.map{|k, v| [k, v]}), required: true, class: 'form-control' %>
+      <%= form.select :level, options_for_select(SiteAlert.levels.keys), required: true, class: 'form-control' %>
       <div class="alert-light" role="alert">
         Specify the level of urgency indicated by this message.
       </div>

--- a/db/migrate/20250715020612_add_integer_enum_columns.rb
+++ b/db/migrate/20250715020612_add_integer_enum_columns.rb
@@ -1,0 +1,14 @@
+class AddIntegerEnumColumns < ActiveRecord::Migration[8.0]
+  def change
+    # Add new integer columns (temporarily suffixed with _int)
+    # Also replicated the default value and null constraints from the existing
+    # string columns
+    add_column :transcripts, :process_status_int, :integer
+    add_column :site_alerts, :level_int, :integer, default: 0, null: false
+    add_column :user_roles, :transcribing_role_int, :integer, default: 0
+
+    add_index :transcripts, :process_status_int
+    add_index :site_alerts, :level_int
+    add_index :user_roles, :transcribing_role_int
+  end
+end

--- a/db/migrate/20250715020636_convert_string_enums_to_integers.rb
+++ b/db/migrate/20250715020636_convert_string_enums_to_integers.rb
@@ -1,0 +1,69 @@
+class ConvertStringEnumsToIntegers < ActiveRecord::Migration[8.0]
+  def up
+    execute <<-SQL
+      UPDATE transcripts
+      SET process_status_int = CASE
+        WHEN process_status = 'started' THEN 0
+        WHEN process_status = 'completed' THEN 1
+        WHEN process_status = 'failed' THEN 2
+        ELSE NULL
+      END
+      WHERE process_status IS NOT NULL;
+    SQL
+
+    execute <<-SQL
+      UPDATE site_alerts
+      SET level_int = CASE
+        WHEN level = 'status' THEN 0
+        WHEN level = 'warning' THEN 1
+        WHEN level = 'error' THEN 2
+        ELSE NULL
+      END
+      WHERE level IS NOT NULL;
+    SQL
+
+    execute <<-SQL
+      UPDATE user_roles
+      SET transcribing_role_int = CASE
+        WHEN transcribing_role = 'registered_user' THEN 0
+        WHEN transcribing_role = 'admin' THEN 1
+        ELSE NULL
+      END
+      WHERE transcribing_role IS NOT NULL;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      UPDATE transcripts
+      SET process_status = CASE
+        WHEN process_status_int = 0 THEN 'started'
+        WHEN process_status_int = 1 THEN 'completed'
+        WHEN process_status_int = 2 THEN 'failed'
+        ELSE NULL
+      END
+      WHERE process_status_int IS NOT NULL;
+    SQL
+
+    execute <<-SQL
+      UPDATE site_alerts
+      SET level = CASE
+        WHEN level_int = 0 THEN 'status'
+        WHEN level_int = 1 THEN 'warning'
+        WHEN level_int = 2 THEN 'error'
+        ELSE NULL
+      END
+      WHERE level_int IS NOT NULL;
+    SQL
+
+    execute <<-SQL
+      UPDATE user_roles
+      SET transcribing_role = CASE
+        WHEN transcribing_role_int = 0 THEN 'registered_user'
+        WHEN transcribing_role_int = 1 THEN 'admin'
+        ELSE NULL
+      END
+      WHERE transcribing_role_int IS NOT NULL;
+    SQL
+  end
+end

--- a/db/migrate/20250715020731_finalize_integer_enum_migration.rb
+++ b/db/migrate/20250715020731_finalize_integer_enum_migration.rb
@@ -1,0 +1,54 @@
+class FinalizeIntegerEnumMigration < ActiveRecord::Migration[8.0]
+  def up
+    remove_column :transcripts, :process_status
+    remove_column :site_alerts, :level
+    remove_column :user_roles, :transcribing_role
+
+    # Rename new integer columns to original names
+    rename_column :transcripts, :process_status_int, :process_status
+    rename_column :site_alerts, :level_int, :level
+    rename_column :user_roles, :transcribing_role_int, :transcribing_role
+  end
+
+  def down
+    rename_column :transcripts, :process_status, :process_status_int
+    rename_column :site_alerts, :level, :level_int
+    rename_column :user_roles, :transcribing_role, :transcribing_role_int
+
+    add_column :transcripts, :process_status, :string
+    add_column :site_alerts, :level, :string
+    add_column :user_roles, :transcribing_role, :string
+
+    execute <<-SQL
+      UPDATE transcripts
+      SET process_status = CASE
+        WHEN process_status_int = 0 THEN 'started'
+        WHEN process_status_int = 1 THEN 'completed'
+        WHEN process_status_int = 2 THEN 'failed'
+        ELSE NULL
+      END
+      WHERE process_status_int IS NOT NULL;
+    SQL
+
+    execute <<-SQL
+      UPDATE site_alerts
+      SET level = CASE
+        WHEN level_int = 0 THEN 'status'
+        WHEN level_int = 1 THEN 'warning'
+        WHEN level_int = 2 THEN 'error'
+        ELSE NULL
+      END
+      WHERE level_int IS NOT NULL;
+    SQL
+
+    execute <<-SQL
+      UPDATE user_roles
+      SET transcribing_role = CASE
+        WHEN transcribing_role_int = 0 THEN 'registered_user'
+        WHEN transcribing_role_int = 1 THEN 'admin'
+        ELSE NULL
+      END
+      WHERE transcribing_role_int IS NOT NULL;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_30_160961) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_15_020731) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -147,7 +147,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_30_160961) do
 
   create_table "site_alerts", force: :cascade do |t|
     t.string "machine_name", null: false
-    t.string "level", default: "status", null: false
     t.text "message"
     t.integer "user_id", default: 0, null: false
     t.boolean "published", default: false
@@ -157,6 +156,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_30_160961) do
     t.datetime "unpublish_at", precision: nil
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "level", default: 0, null: false
+    t.index ["level"], name: "index_site_alerts_on_level"
     t.index ["machine_name"], name: "index_site_alerts_on_machine_name", unique: true
   end
 
@@ -326,7 +327,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_30_160961) do
     t.boolean "publish", default: false
     t.integer "transcript_type", default: 0
     t.string "voicebase_media_id"
-    t.string "process_status"
     t.datetime "process_completed_at", precision: nil
     t.datetime "process_started_at", precision: nil
     t.integer "crop_x"
@@ -334,8 +334,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_30_160961) do
     t.integer "crop_w"
     t.integer "crop_h"
     t.string "process_message"
+    t.integer "process_status"
     t.index ["collection_id"], name: "index_transcripts_on_collection_id"
     t.index ["duration"], name: "index_transcripts_on_duration"
+    t.index ["process_status"], name: "index_transcripts_on_process_status"
     t.index ["project_uid"], name: "index_transcripts_on_project_uid"
     t.index ["transcript_status_id"], name: "index_transcripts_on_transcript_status_id"
     t.index ["uid"], name: "index_transcripts_on_uid", unique: true
@@ -348,8 +350,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_30_160961) do
     t.string "description"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.string "transcribing_role", default: "registered_user"
+    t.integer "transcribing_role", default: 0
     t.index ["name"], name: "index_user_roles_on_name", unique: true
+    t.index ["transcribing_role"], name: "index_user_roles_on_transcribing_role"
   end
 
   create_table "users", force: :cascade do |t|
@@ -402,5 +405,4 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_30_160961) do
     t.datetime "created_at", precision: nil
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
-
 end


### PR DESCRIPTION
### Description
Moved to using Integer Based Enums for the following table columns
- Transcript#process_status
- SiteAlert#level
- UserRole#transcribing_role

### Changes 
- Create a 3 step migration to be able to successfully update from string to integer based enum, While ensuring all existing records will still have their data intact
- Minor updates on enum usage and raw SQL Queries using the stirng based enums