### PR TITLE
Update SpeechToTextJob Carrierwave Audio File Download

### DIFF
--- a/app/jobs/azure/speech_to_text_job.rb
+++ b/app/jobs/azure/speech_to_text_job.rb
@@ -1,5 +1,6 @@
 require 'open-uri'
 require 'shellwords'
+require 'tempfile'
 
 module Azure
   class SpeechToTextJob < ApplicationJob
@@ -9,8 +10,13 @@ module Azure
       transcript = Transcript.find transcript_id
       return if transcript.process_started?
 
-      file = download(transcript.audio)
-      return unless file
+      begin
+        file = download(transcript.audio)
+      rescue StandardError => e
+        Rails.logger.error "=============== Failed to download audio file: #{e.message} ==============="
+        Rails.logger.error '=============== From cache_stored_file! ==============='
+        file = download_alternative(transcript.audio) # Returns Tempfile object
+      end
 
       transcript.update_columns(
         process_status: :started,
@@ -18,7 +24,9 @@ module Azure
         process_started_at: Time.current
       )
 
-      speech_to_text = Azure::SpeechToTextService.new(file: file).recognize
+      # Usage of Tempfile object is still backwards compatible with the old implementation
+      # Hence, No changes are required in the Azure::SpeechToTextService class
+      speech_to_text = Azure::SpeechToTextService.new(file: file.is_a?(String) ? file : file.path).recognize
       lines = speech_to_text.lines
       wav_file = File.open(speech_to_text.wav_file_path)
 
@@ -30,7 +38,7 @@ module Azure
           end
           transcript.update_columns(
             lines: lines.length,
-            duration: `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 #{Shellwords.escape(file.to_s)}`.to_i,
+            duration: `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 #{Shellwords.escape(file.to_s)}`.to_i
           )
         end
       end
@@ -48,22 +56,68 @@ module Azure
       )
       Bugsnag.notify e
     ensure
-      File.delete file if file && File.exist?(file)
-      File.delete speech_to_text&.wav_file_path if File.exist?(speech_to_text&.wav_file_path.to_s)
+      # Handle cleanup for both string paths and Tempfile objects
+      if file
+        if file.respond_to?(:close) && file.respond_to?(:unlink)
+          # Tempfile object - use tempfile cleanup methods
+          file.close unless file.closed?
+          file.unlink
+        elsif file.is_a?(String) && File.exist?(file)
+          # String path - use regular file deletion
+          File.delete(file)
+        end
+      end
+
+      if speech_to_text&.wav_file_path && File.exist?(speech_to_text&.wav_file_path.to_s)
+        File.delete speech_to_text&.wav_file_path
+      end
     end
 
+    # rubocop:disable Metrics/AbcSize
+    # Reference: https://github.com/carrierwaveuploader/carrierwave/wiki/How-to%3A-Recreate-and-reprocess-your-files-stored-on-fog
     def download(audio)
+      # Step 1: Download S3 file to local cache
       audio.cache_stored_file!
-      default_name = Rails.root.join("public", audio.cache_dir, audio.cached?.to_s, audio.file.filename)
-      return default_name if default_name.to_s.size <= 150
 
+      # Step 2: Retrieve the cached file as a SanitizedFile (this converts Fog::File to SanitizedFile)
+      audio.retrieve_from_cache!(audio.cache_name)
+
+      # Step 3: Now we can access the local file path
+      local_path = audio.file.path
+      return local_path if local_path.to_s.size <= 150
+
+      # If the path is too long, create a shorter path
       extension = audio.file.filename.split('.').last
       new_random_name = SecureRandom.hex
-      new_name = Rails.root.join("public", audio.cache_dir, audio.cached?.to_s, "#{new_random_name}.#{extension}")
+      new_name = Rails.public_path.join(audio.cache_dir, "#{new_random_name}.#{extension}")
 
-      File.rename(default_name, new_name)
+      # Ensure the directory exists
+      FileUtils.mkdir_p(File.dirname(new_name))
+
+      File.rename(local_path, new_name)
 
       new_name
     end
+
+    def download_alternative(audio)
+      # Just a fallback method in case the cache_stored_file! fails
+      # Download the remote file to a Tempfile object instead of using the Carrierwave cache
+      file = Tempfile.new(['audio', File.extname(audio.url)])
+      file.binmode
+      URI.open(audio.url) do |remote|
+        file.write(remote.read)
+      end
+      file.flush
+      file.rewind
+
+      file # Return the Tempfile object, not just the path
+    rescue StandardError => e
+      Rails.logger.error "=============== Failed to download audio file: #{e.message} ==============="
+      Rails.logger.error '=============== From download_alternative (Using OpenURI)! ==============='
+      file&.close
+      file&.unlink
+      raise e
+    end
+    # rubocop:enable Metrics/AbcSize
   end
 end


### PR DESCRIPTION
### Issue
A couple of weeks after the Ruby and Ruby on Rails version upgrades, There was an issue found with the `SpeechToTextJob` and was highly pointing into the carrierwave upgrade (From 2.x.x -> 3.x.x)

### Backtrace
```
Exception Azure::SpeechToTextJob@default
unknown file:in `unknown method': ffmpeg version 4.2.7-0ubuntu0.1 Copyright (c) 2000-2022 the FFmpeg developers
  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
  configuration: --prefix=/usr --extra-version=0ubuntu0.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-nvenc --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared
  libavutil      56. 31.100 / 56. 31.100
  libavcodec     58. 54.100 / 58. 54.100
  libavformat    58. 29.100 / 58. 29.100
  libavdevice    58.  8.100 / 58.  8.100
  libavfilter     7. 57.100 /  7. 57.100
  libavresample   4.  0.  0 /  4.  0.  0
  libswscale      5.  5.100 /  5.  5.100
  libswresample   3.  5.100 /  3.  5.100
  libpostproc    55.  5.100 / 55.  5.100
/tmp/carrierwave/true/test_audio_4_aug.wav: No such file or directory
 (Exception)
```

We're seeing similar issues, and the commonality seems to be /tmp/carrierwave/true/{filename}: No such file or directory

### Additional Info
```
Summary: Transcript audio to text processing feature broken
When attaching audio to transcript from admin dashboard, the audio is being uploaded to S3, but the speech to text job is failing.
Here’s the traceback of the issue:
models/transcript.rb
def process_speech_to_text_for_audio_file
speech_to_text_job.rb
def download(audio)
  audio.cache_stored_file!
  default_name = Rails.root.join("public", audio.cache_dir, audio.cached?.to_s, audio.file.filename)
  return default_name if default_name.to_s.size <= 150
The issue seems to be on audio.cache_stored_file! after CarrierWave gem has been upgraded.
```

### Fixes and Changes
There was an issue with the current implementation for downloading the remote audio file (From S3) which was implementedd way back when the app was still using Carrierwave 2.x.x. Updated the current implemention using carrierwave's approach and addedd a fallback using a manual download with OpenURI

- Update the download process using `.cache_stored_file!` 
  - Reference: https://github.com/carrierwaveuploader/carrierwave/wiki/How-to%3A-Recreate-and-reprocess-your-files-stored-on-fog
- Fallback Approach (Use OpenURI to download the remote audio file from S3
