### PR TITLE
Fix Layout/SpaceInsideHashLiteralBraces violations

### DIFF
--- a/app/controllers/transcripts_controller.rb
+++ b/app/controllers/transcripts_controller.rb
@@ -37,8 +37,8 @@ class TranscriptsController < ApplicationController
   def show
     if @institution && @collection && (!params[:institution] || !params[:collection]) && !params[:format]
       transcript_params = [@institution&.slug, @collection.uid, params[:id]]
-      transcript_params.push({t: params[:t]}) if params[:t]
-      transcript_params.push({preview: true}) if params[:preview]
+      transcript_params.push({ t: params[:t] }) if params[:t]
+      transcript_params.push({ preview: true }) if params[:preview]
 
       return redirect_to institution_transcript_path(*transcript_params)
     end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -44,13 +44,13 @@ class Collection < ApplicationRecord
   def self.getForDownloadByVendor(vendor_uid, project_uid)
     vendor = Vendor.find_by_uid(vendor_uid)
     Collection.where('vendor_id = :vendor_id AND vendor_identifier != :empty AND project_uid = :project_uid',
-      {vendor_id: vendor[:id], empty: '', project_uid: project_uid})
+      { vendor_id: vendor[:id], empty: '', project_uid: project_uid })
   end
 
   def self.getForUploadByVendor(vendor_uid, project_uid)
     vendor = Vendor.find_by_uid(vendor_uid)
     Collection.where('vendor_id = :vendor_id AND vendor_identifier = :empty AND project_uid = :project_uid',
-      {vendor_id: vendor[:id], empty: '', project_uid: project_uid})
+      { vendor_id: vendor[:id], empty: '', project_uid: project_uid })
   end
 
   # Instance Methods

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -40,7 +40,7 @@ class Flag < ApplicationRecord
       INNER JOIN transcripts ON flags.transcript_id = transcripts.id
       INNER JOIN transcript_lines ON flags.transcript_line_id = transcript_lines.id')
       .where('flags.is_resolved = :is_resolved AND flags.is_deleted = :is_deleted AND flag_types.category = :category',
-      {is_resolved: 0, is_deleted: 0, category: 'error'})
+      { is_resolved: 0, is_deleted: 0, category: 'error' })
    ar_relation = ar_relation.joins('INNER JOIN collections on transcripts.collection_id = collections.id').where('collections.institution_id = ?', institution_id) if institution_id
    ar_relation.order(:transcript_id, 'transcript_lines.start_time')
   end

--- a/app/models/transcript_line.rb
+++ b/app/models/transcript_line.rb
@@ -54,7 +54,7 @@ pg_search_scope :fuzzy_search, against: [:original_text, :guess_text],
   end
 
   def self.getEditedByTranscriptId(transcript_id)
-    TranscriptLine.joins(:transcript_edits).where(transcript_lines:{transcript_id: transcript_id}).distinct
+    TranscriptLine.joins(:transcript_edits).where(transcript_lines:{ transcript_id: transcript_id }).distinct
   end
 
   def self.getByTranscriptWithSpeakers(transcript_id)
@@ -200,7 +200,7 @@ pg_search_scope :fuzzy_search, against: [:original_text, :guess_text],
       # Group the edits by speaker_id
       groups = edits.group_by{|edit| edit.speaker_id}
       # Convert groups from hash to array
-      groups = groups.collect {|group_speaker_id, group_edits| {speaker_id: group_speaker_id, count: group_edits.length} }
+      groups = groups.collect {|group_speaker_id, group_edits| { speaker_id: group_speaker_id, count: group_edits.length } }
       # Sort by frequency of speaker_id
       groups = groups.sort_by { |group| group[:count] * -1 }
       best_speaker_id = groups[0][:speaker_id]

--- a/app/models/transcript_search.rb
+++ b/app/models/transcript_search.rb
@@ -38,7 +38,7 @@ class TranscriptSearch
 
     @transcripts = transcripts.where('transcripts.published_at IS NOT NULL')
     @transcripts = transcripts.where('collections.published_at IS NOT NULL')
-    @transcripts = transcripts.where('transcripts.project_uid = :project_uid', {project_uid: ENV['PROJECT_ID']})
+    @transcripts = transcripts.where('transcripts.project_uid = :project_uid', { project_uid: ENV['PROJECT_ID'] })
 
     # Check for collection filter
     @transcripts = transcripts.where('collections.title in (?)', options[:collections]) if options[:collections].present?

--- a/app/models/transcript_speaker.rb
+++ b/app/models/transcript_speaker.rb
@@ -5,7 +5,7 @@ class TranscriptSpeaker < ApplicationRecord
 
   def self.getByTranscriptId(transcript_id)
     Rails.cache.fetch("/transcript/#{transcript_id}/speakers", expires_in: 1.hour) do
-      Speaker.joins(:transcript_speakers).where(transcript_speakers:{transcript_id: transcript_id})
+      Speaker.joins(:transcript_speakers).where(transcript_speakers:{ transcript_id: transcript_id })
     end
   end
 end

--- a/lib/tasks/sample.rake
+++ b/lib/tasks/sample.rake
@@ -53,17 +53,17 @@ namespace :sample do
 
   def seedEditsEditing(line)
     # Just one edit
-    seedEdit({transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'one_1', text: '[laughter] Oh, really?'})
-    seedEdit({transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'one_2', text: '[laughing] Oh, really?'})
+    seedEdit({ transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'one_1', text: '[laughter] Oh, really?' })
+    seedEdit({ transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'one_2', text: '[laughing] Oh, really?' })
 
     line.recalculate()
   end
 
   def seedEditsReviewing(line)
     # Many edits, none agree
-    seedEdit({transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'two_1', text: 'Oh. April Fourth, two thousand sixteen'})
-    seedEdit({transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'two_2', text: 'On, um, April fourth, 2016'})
-    seedEdit({transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'two_3', text: 'On April 4th, 2016'})
+    seedEdit({ transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'two_1', text: 'Oh. April Fourth, two thousand sixteen' })
+    seedEdit({ transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'two_2', text: 'On, um, April fourth, 2016' })
+    seedEdit({ transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'two_3', text: 'On April 4th, 2016' })
 
     line.recalculate()
   end
@@ -71,15 +71,15 @@ namespace :sample do
   def seedEditsCompleted(line)
 
     # Many edits, all agree
-    seedEdit({transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'three_1', text: 'Can you tell me more?'})
-    seedEdit({transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'three_2', text: 'can you tell me more?'})
-    seedEdit({transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'three_3', text: 'Can you tell me more'})
+    seedEdit({ transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'three_1', text: 'Can you tell me more?' })
+    seedEdit({ transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'three_2', text: 'can you tell me more?' })
+    seedEdit({ transcript_id: line.transcript_id, transcript_line_id: line.id, session_id: 'three_3', text: 'Can you tell me more' })
 
     line.recalculate()
   end
 
   def seedLine(attributes)
-    line = TranscriptLine.find_or_initialize_by({transcript_id: attributes[:transcript_id], sequence: attributes[:sequence]})
+    line = TranscriptLine.find_or_initialize_by({ transcript_id: attributes[:transcript_id], sequence: attributes[:sequence] })
     line.update(attributes)
     line
   end
@@ -88,14 +88,14 @@ namespace :sample do
     puts 'Seeding transcript lines...'
 
     lines = []
-    lines << seedLine({transcript_id: transcript.id, sequence: 0, start_time: 2, end_time: 2430, original_text: 'oh really', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0})
-    lines << seedLine({transcript_id: transcript.id, sequence: 1, start_time: 2445, end_time: 4480, original_text: 'and we want live', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0})
-    lines << seedLine({transcript_id: transcript.id, sequence: 2, start_time: 4490, end_time: 8230, original_text: 'In april fourth two thousand and sixteen', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0})
-    lines << seedLine({transcript_id: transcript.id, sequence: 3, start_time: 8604, end_time: 10273, original_text: 'can you tell me more', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0})
-    lines << seedLine({transcript_id: transcript.id, sequence: 4, start_time: 10276, end_time: 14560, original_text: 'yah care to start', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0})
-    lines << seedLine({transcript_id: transcript.id, sequence: 5, start_time: 14793, end_time: 16343, original_text: 'why do want to show', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0})
-    lines << seedLine({transcript_id: transcript.id, sequence: 6, start_time: 16711, end_time: 19168, original_text: 'it\'s a community driven project we start with', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0})
-    lines << seedLine({transcript_id: transcript.id, sequence: 7, start_time: 19110, end_time: 21334, original_text: 'with speeched text generation transcripts', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0})
+    lines << seedLine({ transcript_id: transcript.id, sequence: 0, start_time: 2, end_time: 2430, original_text: 'oh really', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0 })
+    lines << seedLine({ transcript_id: transcript.id, sequence: 1, start_time: 2445, end_time: 4480, original_text: 'and we want live', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0 })
+    lines << seedLine({ transcript_id: transcript.id, sequence: 2, start_time: 4490, end_time: 8230, original_text: 'In april fourth two thousand and sixteen', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0 })
+    lines << seedLine({ transcript_id: transcript.id, sequence: 3, start_time: 8604, end_time: 10273, original_text: 'can you tell me more', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0 })
+    lines << seedLine({ transcript_id: transcript.id, sequence: 4, start_time: 10276, end_time: 14560, original_text: 'yah care to start', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0 })
+    lines << seedLine({ transcript_id: transcript.id, sequence: 5, start_time: 14793, end_time: 16343, original_text: 'why do want to show', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0 })
+    lines << seedLine({ transcript_id: transcript.id, sequence: 6, start_time: 16711, end_time: 19168, original_text: 'it\'s a community driven project we start with', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0 })
+    lines << seedLine({ transcript_id: transcript.id, sequence: 7, start_time: 19110, end_time: 21334, original_text: 'with speeched text generation transcripts', guess_text: '', text: '', transcript_line_status_id: 1, speaker_id: 0, flag_count: 0 })
     lines
   end
 
@@ -107,8 +107,8 @@ namespace :sample do
 
   def seedSpeakers(transcript)
     speakers = []
-    speakers << seedSpeaker({name: 'Brian'})
-    speakers << seedSpeaker({name: 'Willa'})
+    speakers << seedSpeaker({ name: 'Brian' })
+    speakers << seedSpeaker({ name: 'Willa' })
 
     speakers.each do |speaker|
       ts = TranscriptSpeaker.find_or_initialize_by(speaker_id: speaker.id, transcript_id: transcript.id)
@@ -119,7 +119,7 @@ namespace :sample do
   def seedTranscript
     puts 'Seeding transcript..'
 
-    attributes = {uid: 'sample-transcript', title: 'Together We Listen Sample', audio_url: '/audio/twl_sample.mp3', lines: 8, duration: 22, transcript_status_id: 1, project_uid: 'sample-project', lines_completed: 0, lines_edited: 0, percent_completed: 0, percent_edited: 0}
+    attributes = { uid: 'sample-transcript', title: 'Together We Listen Sample', audio_url: '/audio/twl_sample.mp3', lines: 8, duration: 22, transcript_status_id: 1, project_uid: 'sample-project', lines_completed: 0, lines_edited: 0, percent_completed: 0, percent_edited: 0 }
     transcript = Transcript.find_or_initialize_by(uid: attributes[:uid])
     transcript.update(attributes)
     transcript

--- a/lib/tasks/transcripts.rake
+++ b/lib/tasks/transcripts.rake
@@ -16,11 +16,11 @@ namespace :transcripts do
     transcripts = Transcript.getForExport(args[:project_key], args[:collection_uid])
 
     formats = [
-      {id: 'text', label: 'Text', urlExt: '.text', fileType: '.txt'},
-      {id: 'text_with_timestamps', label: 'Text With Timestamps', urlExt: '.text?timestamps=1', fileType: '.txt'},
-      {id: 'webvtt', label: 'WebVTT (Captions)', urlExt: '.vtt', fileType: '.vtt'},
-      {id: 'json', label: 'JSON', urlExt: '.json', fileType: '.json'},
-      {id: 'json_with_edits', label: 'JSON With Edits', urlExt: '.json?edits=1', fileType: '.json'}
+      { id: 'text', label: 'Text', urlExt: '.text', fileType: '.txt' },
+      { id: 'text_with_timestamps', label: 'Text With Timestamps', urlExt: '.text?timestamps=1', fileType: '.txt' },
+      { id: 'webvtt', label: 'WebVTT (Captions)', urlExt: '.vtt', fileType: '.vtt' },
+      { id: 'json', label: 'JSON', urlExt: '.json', fileType: '.json' },
+      { id: 'json_with_edits', label: 'JSON With Edits', urlExt: '.json?edits=1', fileType: '.json' }
     ]
 
     transcripts.each do |transcript|

--- a/spec/controllers/admin/cms/collections_controller_spec.rb
+++ b/spec/controllers/admin/cms/collections_controller_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Admin::Cms::CollectionsController, type: :controller do
 
     context 'invalid update request' do
       let(:params) { { uid: '', theme_ids: [''] } }
-      let(:action) { put :update, params: {id: collection.uid, collection: params  } }
+      let(:action) { put :update, params: { id: collection.uid, collection: params  } }
 
       it 'responds with a bad request status' do
         action

--- a/spec/controllers/admin/cms/transcripts_controller_spec.rb
+++ b/spec/controllers/admin/cms/transcripts_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Admin::Cms::TranscriptsController, type: :controller do
   end
 
   describe 'GET #new' do
-    let(:action) { get :new, params: {collection_uid: collection.uid  } }
+    let(:action) { get :new, params: { collection_uid: collection.uid  } }
 
     it 'is successful' do
       action

--- a/test/models/transcript_edit_test.rb
+++ b/test/models/transcript_edit_test.rb
@@ -72,7 +72,7 @@ class TranscriptEditTest < ActiveSupport::TestCase
   end
 
   def seedEdit(attributes)
-    edit = TranscriptEdit.find_or_initialize_by({transcript_line_id: attributes[:transcript_line_id], session_id: attributes[:session_id]})
+    edit = TranscriptEdit.find_or_initialize_by({ transcript_line_id: attributes[:transcript_line_id], session_id: attributes[:session_id] })
     edit.update(attributes)
     edit
   end
@@ -87,11 +87,11 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Consensus: three edits, all agree
   test 'consensus one' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 1, original_text: 'Picture yerself in a goat on a hiver', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 1, original_text: 'Picture yerself in a goat on a hiver', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'one_1', text: 'Picture yourself in a boat on a river'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'one_2', text: 'Picture yourself in a boat on a river'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'one_3', text: 'Picture yourself in a boat on a river'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'one_1', text: 'Picture yourself in a boat on a river' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'one_2', text: 'Picture yourself in a boat on a river' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'one_3', text: 'Picture yourself in a boat on a river' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'Picture yourself in a boat on a river'
@@ -103,12 +103,12 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Consensus: four edits, one is original text, two agree; choose the one with two
   test 'consensus two' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 2, original_text: 'With tanjereen treez and marmalade skyz', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 2, original_text: 'With tanjereen treez and marmalade skyz', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'two_1', text: 'With tangerine trees and marmalade skies'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'two_2', text: 'With tangerine trees and marmalade skies'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'two_3', text: 'With tanjereen treez and marmalade skyz'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'two_4', text: 'With tanjereen trees and marmalade skies'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'two_1', text: 'With tangerine trees and marmalade skies' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'two_2', text: 'With tangerine trees and marmalade skies' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'two_3', text: 'With tanjereen treez and marmalade skyz' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'two_4', text: 'With tanjereen trees and marmalade skies' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'With tangerine trees and marmalade skies'
@@ -120,11 +120,11 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Consensus: three edits, all agree (with normalized text); choose the one with registered user
   test 'consensus three' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 3, original_text: 'Somebody callz u, u answer kwite slowly', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 3, original_text: 'Somebody callz u, u answer kwite slowly', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'three_1', text: 'Somebody calls you, you answer quite slowly.', user_id: @registered_user.id},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'three_2', text: 'somebody calls you you answer quite slowly'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'three_3', text: 'Somebody calls YOU; you answer quite slowly'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'three_1', text: 'Somebody calls you, you answer quite slowly.', user_id: @registered_user.id },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'three_2', text: 'somebody calls you you answer quite slowly' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'three_3', text: 'Somebody calls YOU; you answer quite slowly' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'Somebody calls you, you answer quite slowly.'
@@ -136,11 +136,11 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Consensus: three edits, all agree (with normalized text); choose the one with capitalization and uhms
   test 'consensus four' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 4, original_text: 'A gurl with kaleidoscope eyez', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 4, original_text: 'A gurl with kaleidoscope eyez', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'four_1', text: 'A girl with kaleidoscope--ummm--eyes'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'four_2', text: 'A girl with kaleidoscope eyes'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'four_3', text: 'a girl with kaleidoscope eyes'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'four_1', text: 'A girl with kaleidoscope--ummm--eyes' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'four_2', text: 'A girl with kaleidoscope eyes' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'four_3', text: 'a girl with kaleidoscope eyes' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'A girl with kaleidoscope--ummm--eyes'
@@ -152,11 +152,11 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Consensus: three edits, two agree (with normalized text); choose the one with punctuation
   test 'consensus five' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 5, original_text: 'Sellophane flowerz of yellow and green', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 5, original_text: 'Sellophane flowerz of yellow and green', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'five_1', text: 'Cellophane flowers, of yellow and green.'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'five_2', text: 'Cellophane flowers, of yellow and green'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'five_3', text: 'Cellophane flowerz of yellow and green'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'five_1', text: 'Cellophane flowers, of yellow and green.' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'five_2', text: 'Cellophane flowers, of yellow and green' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'five_3', text: 'Cellophane flowerz of yellow and green' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'Cellophane flowers, of yellow and green.'
@@ -168,11 +168,11 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Guess: three edits, nobody agrees; choose the one with a registered user
   test 'guess one' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 6, original_text: 'Towering over ure hed', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 6, original_text: 'Towering over ure hed', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'six_1', text: 'Towering over your head', user_id: @registered_user.id},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'six_2', text: 'Towering over ure head'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'six_3', text: 'Towering over your hed'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'six_1', text: 'Towering over your head', user_id: @registered_user.id },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'six_2', text: 'Towering over ure head' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'six_3', text: 'Towering over your hed' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'Towering over your head'
@@ -184,12 +184,12 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Guess: three edits, nobody agrees; choose the one with punctuation
   test 'guess two' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 7, original_text: 'Look fer the gurl with the son in her eyez', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 7, original_text: 'Look fer the gurl with the son in her eyez', guess_text: '', text: '', transcript_line_status_id: 1 })
 
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'seven_1', text: 'Look for the girl, with the sun in her eyes.'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'seven_2', text: 'Look fer the girl with the son in her eyez'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'seven_3', text: 'Look fer the gurl, with the sun in her eyes'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'seven_1', text: 'Look for the girl, with the sun in her eyes.' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'seven_2', text: 'Look fer the girl with the son in her eyez' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'seven_3', text: 'Look fer the gurl, with the sun in her eyes' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'Look for the girl, with the sun in her eyes.'
@@ -201,11 +201,11 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Guess: three edits, nobody agrees; choose the one with numbers
   test 'guess three' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 8, original_text: 'And she\'s gawn', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 8, original_text: 'And she\'s gawn', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'eight_1', text: 'And shes 4 gone'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'eight_2', text: 'And shes gun'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'eight_3', text: 'And she is gawn'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'eight_1', text: 'And shes 4 gone' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'eight_2', text: 'And shes gun' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'eight_3', text: 'And she is gawn' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'And shes 4 gone'
@@ -217,13 +217,13 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Review: five edits, nobody agrees; make into "review" status
   test 'review one' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 9, original_text: 'Loosie in the skie wit diamondz', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 9, original_text: 'Loosie in the skie wit diamondz', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'nine_1', text: 'Loosie in the sky wit diamondz'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'nine_2', text: 'Loosie in the skie with diamondz'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'nine_3', text: 'Loosie in the skie wit diamonds'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'nine_4', text: 'Lucy in the skie wit diamondz'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'nine_5', text: 'Lucy in the sky with diamonds'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'nine_1', text: 'Loosie in the sky wit diamondz' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'nine_2', text: 'Loosie in the skie with diamondz' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'nine_3', text: 'Loosie in the skie wit diamonds' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'nine_4', text: 'Lucy in the skie wit diamondz' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'nine_5', text: 'Lucy in the sky with diamonds' }
     ])
     line.recalculate(nil, @project)
 
@@ -234,11 +234,11 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Consensus: three edits, two agree, one is an admin; choose the one by an admin
   test 'consensus six' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 10, original_text: 'Follow er down to a bridge bye a fountane', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 10, original_text: 'Follow er down to a bridge bye a fountane', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'ten_1', text: 'Follow her down to a bridge by a fountain', user_id: @admin_user.id},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'ten_2', text: 'Follow her down to a bridge, bye a fountane'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'ten_3', text: 'Follow her down to a bridge, bye a fountane'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'ten_1', text: 'Follow her down to a bridge by a fountain', user_id: @admin_user.id },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'ten_2', text: 'Follow her down to a bridge, bye a fountane' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'ten_3', text: 'Follow her down to a bridge, bye a fountane' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'Follow her down to a bridge by a fountain'
@@ -250,11 +250,11 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Consensus: three edits, nobody agrees, one is an admin; choose the one by an admin
   test 'consensus seven' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 11, original_text: 'wear rocking horse ppl eat marshmellow piez', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 11, original_text: 'wear rocking horse ppl eat marshmellow piez', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'eleven_1', text: 'Where rocking horse people eat marshmallow pies', user_id: @admin_user.id},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'eleven_2', text: 'wear rocking horse pepole eat marshmellow pies?'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'eleven_3', text: 'Where rocking horse ppl eat marshmellow piez'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'eleven_1', text: 'Where rocking horse people eat marshmallow pies', user_id: @admin_user.id },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'eleven_2', text: 'wear rocking horse pepole eat marshmellow pies?' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'eleven_3', text: 'Where rocking horse ppl eat marshmellow piez' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'Where rocking horse people eat marshmallow pies'
@@ -266,9 +266,9 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Guess: one edit, the guess should be that one
   test 'guess four' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 12, original_text: 'Every1 smiles as you drift passed da flowerz', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 12, original_text: 'Every1 smiles as you drift passed da flowerz', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'twelve_1', text: 'Everyone smiles as you drift past the flowers'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'twelve_1', text: 'Everyone smiles as you drift past the flowers' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'Everyone smiles as you drift past the flowers'
@@ -280,13 +280,13 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Consensus: five edits, all are original text; choose the original text
   test 'consensus eight' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 13, original_text: 'That grow so incredibly high', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 13, original_text: 'That grow so incredibly high', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'thirteen_1', text: 'That grow so incredibly high'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'thirteen_2', text: 'That grow so incredibly high'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'thirteen_3', text: 'That grow so incredibly high'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'thirteen_4', text: 'That grow so incredibly high'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'thirteen_5', text: 'That grow so incredibly high'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'thirteen_1', text: 'That grow so incredibly high' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'thirteen_2', text: 'That grow so incredibly high' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'thirteen_3', text: 'That grow so incredibly high' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'thirteen_4', text: 'That grow so incredibly high' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'thirteen_5', text: 'That grow so incredibly high' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'That grow so incredibly high'
@@ -298,11 +298,11 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Consensus: three edits, one original text by admin, two others not original; choose the one by the admin
   test 'consensus nine' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 14, original_text: 'Newspaper taxis appear on the shore', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 14, original_text: 'Newspaper taxis appear on the shore', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'fourteen_1', text: 'Newspaper taxiz appear on the sure'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'fourteen_2', text: 'Newspaper taxiz appear on the sure'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'fourteen_3', text: 'Newspaper taxis appear on the shore', user_id: @admin_user.id}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'fourteen_1', text: 'Newspaper taxiz appear on the sure' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'fourteen_2', text: 'Newspaper taxiz appear on the sure' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'fourteen_3', text: 'Newspaper taxis appear on the shore', user_id: @admin_user.id }
     ])
     line.recalculate(nil, @project)
     correct_text = 'Newspaper taxis appear on the shore'
@@ -314,8 +314,8 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Test normalization of text
   test 'normalized text one' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 15, original_text: 'Waiting to take you away', guess_text: '', text: '', transcript_line_status_id: 1})
-    edit = seedEdit({transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'fifteen_1', text: 'Waiting?  to, uhm, um--uhmm TAKE you awayum! '})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 15, original_text: 'Waiting to take you away', guess_text: '', text: '', transcript_line_status_id: 1 })
+    edit = seedEdit({ transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'fifteen_1', text: 'Waiting?  to, uhm, um--uhmm TAKE you awayum! ' })
     correct_text = 'waiting to take you awayum'
 
     assert edit.normalizedText == correct_text, 'Normalized text correct'
@@ -323,10 +323,10 @@ class TranscriptEditTest < ActiveSupport::TestCase
 
   # Consensus: two edits, both agree; choose that one (it doesn't matter what the third is)
   test 'consensus ten' do
-    line = seedLine({transcript_id: @transcript.id, sequence: 16, original_text: 'Waiting 2 take u away', guess_text: '', text: '', transcript_line_status_id: 1})
+    line = seedLine({ transcript_id: @transcript.id, sequence: 16, original_text: 'Waiting 2 take u away', guess_text: '', text: '', transcript_line_status_id: 1 })
     seedEdits([
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'sixteen_1', text: 'Waiting to take you away'},
-      {transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'sixteen_2', text: 'Waiting to take you away'}
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'sixteen_1', text: 'Waiting to take you away' },
+      { transcript_id: @transcript.id, transcript_line_id: line.id, session_id: 'sixteen_2', text: 'Waiting to take you away' }
     ])
     line.recalculate(nil, @project)
     correct_text = 'Waiting to take you away'


### PR DESCRIPTION
# Fix Layout/SpaceInsideHashLiteralBraces violations

## Summary

This PR standardizes hash formatting across the codebase by fixing all `Layout/SpaceInsideHashLiteralBraces` violations. This ensures consistent spacing inside hash literal braces throughout the application.

## Changes

- **Fixed 200 RuboCop violations** of `Layout/SpaceInsideHashLiteralBraces`
- **Standardized hash formatting** from inconsistent `{key: value}` vs `{ key: value }` to consistent style
- **Auto-corrected using RuboCop** with `bundle exec rubocop -a --only Layout/SpaceInsideHashLiteralBraces`
- **Zero semantic changes** - purely formatting improvements

## Impact

### Code Quality
- ✅ Improved code consistency and readability
- ✅ Reduced RuboCop violations by 200 (continuing systematic cleanup)
- ✅ Standardized hash formatting across models, controllers, specs, and tasks

### Safety
- ✅ **Safe auto-correctable changes only** - no logic modifications
- ✅ **All syntax validated** - no parsing errors introduced
- ✅ **Rails application verified** - loads successfully after changes

## Files Modified

The changes affect hash formatting in:
- Model files (`app/models/`)
- Controller files (`app/controllers/`)
- Spec files (`spec/`)
- Test files (`test/`)
- Rake tasks (`lib/tasks/`)

## Testing

- [x] Rails application starts successfully
- [x] Syntax validation passes for all modified files
- [x] No functional regressions (formatting-only changes)
- [x] Part of systematic RuboCop cleanup strategy

## Commands Used

```bash
# Auto-fix violations
bundle exec rubocop -a --only Layout/SpaceInsideHashLiteralBraces

# Verify fix
bundle exec rubocop --only Layout/SpaceInsideHashLiteralBraces --format offenses

# Test application
bundle exec rails runner "puts 'Application loads successfully'"
```

## Before/After

**Before**: 200 `Layout/SpaceInsideHashLiteralBraces` violations  
**After**: 0 violations ✅

**Total Progress**: 1,376 RuboCop violations eliminated across 2 PRs

---

**Type**: Chore  
**Risk**: Very Low (formatting only)  
**Review Focus**: Verify consistent hash formatting and no syntax errors
